### PR TITLE
fix(ci): grant orchestrator permissions for reusable workflows

### DIFF
--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -25,6 +25,11 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
 jobs:
   resolve:
     runs-on: ubuntu-latest


### PR DESCRIPTION
First dispatch of \`release-pipeline.yaml\` after #29 merged hit \`startup_failure\` (run [26197205748](https://github.com/ML4GLand/SeqPro/actions/runs/26197205748)). The called workflows declare permissions (merge: \`id-token: write\`; publish release job: \`id-token / contents / attestations: write\`) that the orchestrator wasn't granting — reusable workflows can only request permissions the caller has.

Adds top-level \`permissions:\` block on the orchestrator with the union of what its callees need: \`contents: write\`, \`id-token: write\`, \`attestations: write\`.

## Test plan
- [ ] After merge, re-dispatch \`release-pipeline.yaml\` with \`increment=PATCH\` and confirm the four called workflows actually queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)