### PR TITLE
fix(ci): publish checks out bumped tag, not dispatch SHA

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,6 +20,11 @@ on:
         type: boolean
         required: false
         default: false
+      tag:
+        description: 'Tag to check out and build wheels from (defaults to caller ref)'
+        type: string
+        required: false
+        default: ''
   workflow_dispatch:
     inputs:
       dry_run:
@@ -27,6 +32,11 @@ on:
         type: boolean
         required: false
         default: false
+      tag:
+        description: 'Tag to check out and build wheels from (defaults to current ref)'
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -51,6 +61,8 @@ jobs:
             target: ppc64le
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
@@ -89,6 +101,8 @@ jobs:
             target: armv7
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
@@ -128,6 +142,8 @@ jobs:
             python_arch: arm64
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
@@ -165,6 +181,8 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
@@ -193,6 +211,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -84,11 +84,12 @@ jobs:
       dry_run: ${{ inputs.dry_run }}
 
   publish:
-    needs: release
+    needs: [resolve, bump, release]
     uses: ./.github/workflows/publish.yaml
     secrets: inherit
     with:
       dry_run: ${{ inputs.dry_run }}
+      tag: ${{ needs.bump.outputs.tag || needs.resolve.outputs.tag }}
 
   merge:
     needs: publish


### PR DESCRIPTION
First end-to-end run of the new release pipeline (#26197560838) succeeded through bump + release, but `Publish to PyPI` failed:
\`\`\`
error: Failed to publish wheels-linux-aarch64/seqpro-0.11.0-cp39-abi3-...whl
  Caused by: 400 File already exists ('seqpro-0.11.0-...whl')
\`\`\`
Root cause: the matrix jobs in `publish.yaml` do `actions/checkout@v6` without specifying a ref, so they got the orchestrator's dispatch commit (pre-bump), built wheels labelled \`0.11.0\`, and tried to upload them — but 0.11.0 already exists on PyPI.

The bump commit + 0.11.1 tag *had* been pushed, but they came after the dispatch's frozen \`github.sha\`.

## Fix
- `publish.yaml`: add a `tag` input on both `workflow_call` and `workflow_dispatch`, thread it into the `ref:` of every matrix job's `actions/checkout` (linux, musllinux, windows, macos, sdist).
- `release-pipeline.yaml`: extend `publish`'s `needs:` to include `resolve` and `bump`, and pass `${{ needs.bump.outputs.tag || needs.resolve.outputs.tag }}` as the new `tag` input.

## Recovery
Tag 0.11.1, the GH Release, and the pyproject bump are all already on main. After this PR merges, re-dispatch \`release-pipeline.yaml\` with \`skip_bump=true, tag=0.11.1\` — publish will check out the right ref, build the right wheels, push to PyPI, and merge will fast-forward stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)