### PR TITLE
fix(ci): publish runs when bump skipped on skip_bump=true recovery

### DIFF
--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -85,6 +85,7 @@ jobs:
 
   publish:
     needs: [resolve, bump, release]
+    if: always() && needs.release.result == 'success'
     uses: ./.github/workflows/publish.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
After PR #31 fixed publish to check out the bumped tag, I re-dispatched with \`skip_bump=true, tag=0.11.1\` (run [26197925759](https://github.com/ML4GLand/SeqPro/actions/runs/26197925759)). \`resolve\` and \`release\` ran; \`publish\` and \`merge\` *skipped* with no logs.

Reason: when bump's \`if: inputs.skip_bump == false\` evaluates to false, GH marks bump as 'skipped'. \`publish\` has \`needs: [resolve, bump, release]\` and by default skips when any need is skipped. The \`release\` job already handles this via \`always() && (bump success or skipped)\`; \`publish\` was missing the equivalent.

## Fix
Add \`if: always() && needs.release.result == 'success'\` on \`publish\`. \`release\` only succeeds when the resolve+bump chain is healthy, so this transitively guarantees correctness. \`merge\` already needs only \`publish\` and doesn't need an \`always()\` clause — if publish skipped, merge correctly skips too.

## Recovery
After merge, re-dispatch with \`skip_bump=true, tag=0.11.1\` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)