### PR TITLE
fix(ci): merge job runs after transitive skip recovery

### DIFF
--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -94,6 +94,7 @@ jobs:
 
   merge:
     needs: publish
+    if: always() && needs.publish.result == 'success'
     uses: ./.github/workflows/merge.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
Last piece of the release-pipeline fixes from the 0.11.1 release.

After PR #32 added \`always()\` to \`publish\` so \`skip_bump=true\` reruns work, the third dispatch ([26198057991](https://github.com/ML4GLand/SeqPro/actions/runs/26198057991)) succeeded through publish (PyPI got 0.11.1) but \`merge\` skipped despite publish reporting success. GitHub Actions applies transitive-skip semantics through an \`always()\`-recovered chain: bump skipped → propagates through release/publish (recovered by \`always()\`) → merge default semantics still see "tainted" upstream and skip.

## Fix
Same pattern release and publish already use:
\`\`\`yaml
merge:
  needs: publish
  if: always() && needs.publish.result == 'success'
\`\`\`

\`stable\` for 0.11.1 was advanced by dispatching \`merge.yaml\` standalone ([run 26198310126](https://github.com/ML4GLand/SeqPro/actions/runs/26198310126)). This PR ensures future releases don't need the manual nudge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)