### PR TITLE
feat(translate): codon→AA LUT (dense + Ragged) with optional input validation

### DIFF
--- a/docs/superpowers/plans/2026-05-28-translate-lut-validation.md
+++ b/docs/superpowers/plans/2026-05-28-translate-lut-validation.md
@@ -1,0 +1,793 @@
+# Translate LUT Completion + Input Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `AminoAlphabet.translate` safe and complete — add an opt-in `validate` flag that guarantees in-alphabet input, route the Ragged path through the O(1) codon LUT, and remove the maintainability/clarity smells left by PR #35.
+
+**Architecture:** Build on commit `779bd97` (PR #35's LUT work, already in this branch). The bit-pack hash gets a single njit source of truth; LUT construction is gated by an explicit predicate instead of try/except; a `validate` flag runs a vectorized in-alphabet check (byte membership for string input, structural one-hot check for OHE input) before any kernel; the Ragged path gains the same `codon_lut`-vs-fallback branch the dense path already has.
+
+**Tech Stack:** Python, NumPy, Numba (`@nb.njit` / `@nb.guvectorize`), awkward-array (`Ragged`), pytest + hypothesis + pytest-cases, BioPython (test ground truth), pixi (env), commitizen (conventional commits).
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `python/seqpro/_numba.py` | Numba kernels. Add `_pack_codon_index` njit helper (single source of truth for the codon→index hash); `gufunc_translate_lut` calls it. Strip speed claims from docstrings. | Modify |
+| `python/seqpro/alphabets/_alphabets.py` | `AminoAlphabet`. Add `_can_build_lut` predicate, `_valid_nuc_bytes`, `_check_nuc_bytes`, `_check_ohe_rows`, `validate` kwarg on `translate`, Ragged LUT branch. `_build_translate_lut` no longer raises. | Modify |
+| `tests/test_translate.py` | New tests for predicate, validation (byte + OHE), Ragged LUT, fallback. | Modify |
+| `tests/bench_translate_lut.py` | Benchmark (renamed from `tests/test_translate_lut_bench.py` so pytest stops collecting it). | Rename + edit |
+| `skills/seqpro/SKILL.md` | Document the `validate` flag (required by CLAUDE.md for public-signature changes). | Modify |
+
+**Environment note:** All commands run inside the dev environment. Prefix with `pixi run -e dev`. No `maturin develop` is needed — only Python (`_numba.py` is Numba-JIT, not the Rust extension). Numba recompiles changed kernels automatically.
+
+**Baseline check (run once before starting):**
+
+```bash
+pixi run -e dev pytest tests/test_translate.py -q
+```
+Expected: all pass (this is the regression baseline the refactors must preserve).
+
+---
+
+### Task 1: Single source of truth for the codon→index hash
+
+**Files:**
+- Modify: `python/seqpro/_numba.py` (add `_pack_codon_index` before `gufunc_translate_lut` at line 145; update `gufunc_translate_lut` body at lines 191-195)
+- Modify: `python/seqpro/alphabets/_alphabets.py` (import + use in `_build_translate_lut`, lines 10-16 and 254-267)
+- Test: `tests/test_translate.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_translate.py` (after the existing `# --- LUT path tests ---` block):
+
+```python
+def test_pack_codon_index_bijective_over_acgt():
+    """The 64 ACGT codons map to 64 distinct indices covering exactly [0, 63]."""
+    from seqpro._numba import _pack_codon_index
+
+    idxs = set()
+    for a in "ACGT":
+        for b in "ACGT":
+            for c in "ACGT":
+                idxs.add(int(_pack_codon_index(ord(a), ord(b), ord(c))))
+    assert idxs == set(range(64))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_translate.py::test_pack_codon_index_bijective_over_acgt -v`
+Expected: FAIL with `ImportError: cannot import name '_pack_codon_index'`
+
+- [ ] **Step 3: Add the njit helper in `_numba.py`**
+
+Insert immediately before the `@nb.guvectorize` decorator of `gufunc_translate_lut` (currently line 145):
+
+```python
+@nb.njit(cache=True)
+def _pack_codon_index(b0, b1, b2):
+    """Pack a 3-codon's ASCII bytes into a 6-bit LUT index in ``[0, 63]``.
+
+    Uses the 2-bit-per-nucleotide hash ``(byte >> 1) & 3``, a bijection on
+    ``{A, C, G, T}``. This is the single source of truth for the codon→index
+    mapping: both the runtime lookup (:func:`gufunc_translate_lut`) and the
+    table builder (``_build_translate_lut``) call it, so they cannot drift
+    out of sync.
+    """
+    n0 = (b0 >> 1) & 3
+    n1 = (b1 >> 1) & 3
+    n2 = (b2 >> 1) & 3
+    return (n0 << 4) | (n1 << 2) | n2
+```
+
+- [ ] **Step 4: Use the helper in `gufunc_translate_lut`**
+
+Replace the body of `gufunc_translate_lut` (currently lines 191-195):
+
+```python
+    n0 = (seq_kmers[0] >> 1) & 3
+    n1 = (seq_kmers[1] >> 1) & 3
+    n2 = (seq_kmers[2] >> 1) & 3
+    idx = (n0 << 4) | (n1 << 2) | n2
+    res[0] = codon_lut[idx]
+```
+
+with:
+
+```python
+    res[0] = codon_lut[_pack_codon_index(seq_kmers[0], seq_kmers[1], seq_kmers[2])]
+```
+
+- [ ] **Step 5: Use the helper in `_build_translate_lut`**
+
+In `python/seqpro/alphabets/_alphabets.py`, add `_pack_codon_index` to the `_numba` import block (currently lines 10-16):
+
+```python
+from .._numba import (
+    _nb_find_stop_ends,
+    _pack_codon_index,
+    gufunc_complement_bytes,
+    gufunc_translate,
+    gufunc_translate_lut,
+    ufunc_comp_dna,
+)
+```
+
+Then in `_build_translate_lut`, replace the index computation (currently lines 262-265):
+
+```python
+        n0 = (n0_byte >> 1) & 3
+        n1 = (n1_byte >> 1) & 3
+        n2 = (n2_byte >> 1) & 3
+        idx = (n0 << 4) | (n1 << 2) | n2
+```
+
+with:
+
+```python
+        idx = _pack_codon_index(n0_byte, n1_byte, n2_byte)
+```
+
+(Leave the surrounding `for codon, aa in zip(...)` loop and validation untouched in this task — that is cleaned up in Task 2.)
+
+- [ ] **Step 6: Run the new test and the full translate suite**
+
+Run: `pixi run -e dev pytest tests/test_translate.py -q`
+Expected: PASS — the new test passes and all pre-existing translate tests stay green (the refactor is behavior-preserving).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add python/seqpro/_numba.py python/seqpro/alphabets/_alphabets.py tests/test_translate.py
+git commit -m "refactor(translate): single source of truth for codon LUT index"
+```
+
+---
+
+### Task 2: Gate LUT build with a predicate; drop exception control-flow
+
+**Files:**
+- Modify: `python/seqpro/alphabets/_alphabets.py` (`_build_translate_lut` lines 223-267; new `_can_build_lut`; `__init__` lines 317-323)
+- Test: `tests/test_translate.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_translate.py`:
+
+```python
+def test_can_build_lut_predicate():
+    from seqpro.alphabets._alphabets import _can_build_lut
+
+    assert _can_build_lut(["ATG", "AAA"]) is True
+    assert _can_build_lut(["AUG"]) is False  # U is not in ACGT
+    assert _can_build_lut(["AT", "ATG"]) is False  # not all length-3
+    assert _can_build_lut(["AT"]) is False
+
+
+def test_nonstandard_alphabet_has_no_lut():
+    """A non-ACGT alphabet falls back: codon_lut is None."""
+    alpha = sp.AminoAlphabet(["AUG", "UAA"], ["M", "*"])
+    assert alpha.codon_lut is None
+
+
+def test_partial_acgt_alphabet_fills_unknown_with_X():
+    """A k=3 ACGT alphabet missing codons still builds a LUT; absent codons
+    resolve to the 'X' sentinel rather than garbage."""
+    from seqpro._numba import _pack_codon_index
+
+    alpha = sp.AminoAlphabet(["ATG"], ["M"])
+    assert alpha.codon_lut is not None
+    idx_atg = int(_pack_codon_index(ord("A"), ord("T"), ord("G")))
+    assert chr(alpha.codon_lut[idx_atg]) == "M"
+    idx_aaa = int(_pack_codon_index(ord("A"), ord("A"), ord("A")))
+    assert chr(alpha.codon_lut[idx_aaa]) == "X"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pixi run -e dev pytest tests/test_translate.py::test_can_build_lut_predicate -v`
+Expected: FAIL with `ImportError: cannot import name '_can_build_lut'`
+
+- [ ] **Step 3: Add the `_can_build_lut` predicate**
+
+In `python/seqpro/alphabets/_alphabets.py`, immediately before `def _build_translate_lut(` (currently line 223):
+
+```python
+def _can_build_lut(codons: list[str]) -> bool:
+    """True when the standard O(1) LUT path applies: every codon is length-3
+    and uses only the four standard nucleotides A, C, G, T. Non-standard
+    alphabets (different codon size or extended/IUPAC characters) use the
+    generic :func:`gufunc_translate` scan instead."""
+    return all(len(c) == 3 and set(c) <= set("ACGT") for c in codons)
+```
+
+- [ ] **Step 4: Make `_build_translate_lut` non-raising and fix its docstring**
+
+Replace the entire `_build_translate_lut` function (currently lines 223-267) with:
+
+```python
+def _build_translate_lut(
+    codons: list[str], amino_acids: list[str]
+) -> NDArray[np.uint8]:
+    """Build the 64-entry codon→AA lookup table consumed by ``gufunc_translate_lut``.
+
+    The packed index for each codon is computed by ``_pack_codon_index`` — the
+    same hash the runtime uses — so the table and the lookup cannot drift.
+
+    Callers must gate construction with ``_can_build_lut`` (length-3, ACGT-only
+    codons); this function does not re-validate. The table is initialised to the
+    ``'X'`` (unknown amino acid) byte so that a *partial* standard alphabet — one
+    that is ACGT/k=3 but omits some of the 64 codons — resolves missing codons to
+    ``'X'`` rather than uninitialised memory. For the complete standard genetic
+    code all 64 slots are overwritten.
+
+    Parameters
+    ----------
+    codons
+        List of length-3 DNA strings (uppercase ACGT).
+    amino_acids
+        List of single-character amino-acid strings, aligned with ``codons``.
+
+    Returns
+    -------
+    NDArray[np.uint8]
+        Shape ``(64,)``; ``lut[idx]`` is the AA byte for the codon at packed
+        index ``idx``.
+    """
+    lut = np.full(64, ord("X"), dtype=np.uint8)
+    for codon, aa in zip(codons, amino_acids, strict=True):
+        idx = _pack_codon_index(ord(codon[0]), ord(codon[1]), ord(codon[2]))
+        lut[idx] = ord(aa)
+    return lut
+```
+
+- [ ] **Step 5: Replace try/except with the predicate in `__init__`**
+
+In `AminoAlphabet.__init__`, replace the LUT-build block (currently lines 317-323):
+
+```python
+        # Build the 64-entry O(1) lookup table when the alphabet is the
+        # standard ACGT × k=3 case; fall back to the generic linear-scan
+        # path for non-standard alphabets.
+        try:
+            self.codon_lut = _build_translate_lut(codons, amino_acids)
+        except ValueError:
+            self.codon_lut = None
+```
+
+with:
+
+```python
+        # Build the 64-entry O(1) lookup table only for the standard ACGT × k=3
+        # case; non-standard alphabets use the generic linear-scan path.
+        if _can_build_lut(codons):
+            self.codon_lut = _build_translate_lut(codons, amino_acids)
+        else:
+            self.codon_lut = None
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `pixi run -e dev pytest tests/test_translate.py -q`
+Expected: PASS — new predicate/fallback/partial tests pass; existing tests stay green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add python/seqpro/alphabets/_alphabets.py tests/test_translate.py
+git commit -m "refactor(translate): gate LUT build with predicate, drop exception control-flow"
+```
+
+---
+
+### Task 3: Add `validate` flag — byte-membership path
+
+**Files:**
+- Modify: `python/seqpro/alphabets/_alphabets.py` (class attr near line 276; `__init__` add `_valid_nuc_bytes`; new `_check_nuc_bytes`; `validate` on 3 overloads + impl; dense + Ragged-bytes call sites)
+- Test: `tests/test_translate.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_translate.py`:
+
+```python
+def test_translate_validate_passes_on_valid_acgt():
+    # Should not raise.
+    sp.AA.translate("ATGAAA", length_axis=-1, validate=True)
+
+
+def test_translate_validate_raises_on_lowercase():
+    with pytest.raises(ValueError, match="outside the alphabet"):
+        sp.AA.translate("atgAAA", length_axis=-1, validate=True)
+
+
+def test_translate_validate_raises_on_N():
+    with pytest.raises(ValueError, match="outside the alphabet"):
+        sp.AA.translate("ATGNNN", length_axis=-1, validate=True)
+
+
+def test_translate_validate_false_does_not_raise_on_invalid():
+    # Default path performs no validation and must not raise.
+    out = sp.AA.translate("ATGNNN", length_axis=-1, validate=False)
+    assert out.shape[-1] == 2
+
+
+def test_translate_ragged_bytes_validate_raises():
+    rag = _make_ragged_bytes("ATGNNN")
+    with pytest.raises(ValueError, match="outside the alphabet"):
+        sp.AA.translate(rag, validate=True)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pixi run -e dev pytest tests/test_translate.py::test_translate_validate_raises_on_N -v`
+Expected: FAIL with `TypeError: translate() got an unexpected keyword argument 'validate'`
+
+- [ ] **Step 3: Declare the attribute and precompute the valid-byte set**
+
+In `python/seqpro/alphabets/_alphabets.py`, add a class attribute after the `codon_lut` declaration/docstring (currently ends line 280):
+
+```python
+    _valid_nuc_bytes: NDArray[np.uint8]
+    """Unique nucleotide bytes across all codons (e.g. ``ACGT`` for the standard
+    alphabet), used by ``translate(validate=True)`` to check string input."""
+```
+
+In `__init__`, after the `self.codon_lut = ...` block from Task 2 (the new if/else), add:
+
+```python
+        # Unique nucleotide bytes across all codons, for translate(validate=True).
+        nuc_chars = sorted({c for codon in codons for c in codon})
+        self._valid_nuc_bytes = np.array(
+            [ord(c) for c in nuc_chars], dtype=np.uint8
+        )
+```
+
+- [ ] **Step 4: Add the `_check_nuc_bytes` helper**
+
+Add as a method on `AminoAlphabet` (place it just before the `@overload` block for `translate`, currently line 325):
+
+```python
+    def _check_nuc_bytes(self, buf: NDArray[np.uint8]) -> None:
+        """Raise ``ValueError`` if any byte in ``buf`` is outside the alphabet's
+        nucleotides. Used by ``translate(validate=True)`` for string input."""
+        ok = np.isin(buf, self._valid_nuc_bytes)
+        if not bool(ok.all()):
+            bad = np.unique(buf[~ok]).astype(np.uint8).tobytes().decode(
+                "ascii", "replace"
+            )
+            allowed = self._valid_nuc_bytes.tobytes().decode("ascii")
+            raise ValueError(
+                f"translate(validate=True): input contains characters outside "
+                f"the alphabet {{{allowed}}}: found {bad!r}."
+            )
+```
+
+- [ ] **Step 5: Add `validate` to all three overloads and the implementation**
+
+In each of the three `@overload def translate(...)` signatures and the implementation `def translate(...)` (currently lines 325-359), add a keyword-only parameter after `truncate_stop: bool = False,`:
+
+```python
+        validate: bool = False,
+```
+
+So each signature's keyword-only block reads:
+
+```python
+        *,
+        nuc_alphabet: NucleotideAlphabet | None = None,
+        truncate_stop: bool = False,
+        validate: bool = False,
+```
+
+(The third overload keeps `nuc_alphabet: NucleotideAlphabet` without a default — only append `validate: bool = False` to it.)
+
+Add a `validate` entry to the implementation's docstring Parameters section (after `truncate_stop`):
+
+```python
+        validate
+            When True, raise ValueError if any input nucleotide is outside this
+            alphabet (e.g. lowercase, ``N``, or other non-ACGT bytes; for OHE
+            input, any row that is not exactly one-hot). When validation passes,
+            the translation is guaranteed exact. Default False (no checking).
+```
+
+- [ ] **Step 6: Call the check in the dense path**
+
+In the dense branch, immediately after `seqs = cast_seqs(seqs)` (currently line 383):
+
+```python
+            if validate:
+                self._check_nuc_bytes(seqs.view(np.uint8))
+```
+
+- [ ] **Step 7: Call the check in the Ragged-bytes path**
+
+In the Ragged branch, the `else` arm that sets `nuc_bytes_flat = seqs.data` (currently lines 436-437) becomes:
+
+```python
+        else:
+            nuc_bytes_flat = seqs.data
+            if validate:
+                self._check_nuc_bytes(nuc_bytes_flat.view(np.uint8))
+```
+
+- [ ] **Step 8: Run tests**
+
+Run: `pixi run -e dev pytest tests/test_translate.py -q`
+Expected: PASS — the five new `validate` byte tests pass; existing tests stay green.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add python/seqpro/alphabets/_alphabets.py tests/test_translate.py
+git commit -m "feat(translate): add validate flag for nucleotide input checking"
+```
+
+---
+
+### Task 4: `validate` for OHE Ragged input (structural one-hot check)
+
+**Files:**
+- Modify: `python/seqpro/alphabets/_alphabets.py` (new `_check_ohe_rows`; call in the `is_ohe` branch)
+- Test: `tests/test_translate.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_translate.py`:
+
+```python
+def test_translate_ohe_validate_passes_valid():
+    ohe = sp.DNA.ohe(sp.cast_seqs("ATCGAT"))
+    rag = Ragged.from_lengths(ohe, np.array([6]))
+    # Should not raise.
+    sp.AA.translate(rag, nuc_alphabet=sp.DNA, validate=True)
+
+
+def test_translate_ohe_validate_raises_multihot():
+    ohe = sp.DNA.ohe(sp.cast_seqs("ATCGAT")).copy()
+    ohe[0, :] = 1  # multi-hot row (sum == 4)
+    rag = Ragged.from_lengths(ohe, np.array([6]))
+    with pytest.raises(ValueError, match="one-hot"):
+        sp.AA.translate(rag, nuc_alphabet=sp.DNA, validate=True)
+
+
+def test_translate_ohe_validate_raises_allzero():
+    ohe = sp.DNA.ohe(sp.cast_seqs("ATCGAT")).copy()
+    ohe[0, :] = 0  # all-zero row (sum == 0)
+    rag = Ragged.from_lengths(ohe, np.array([6]))
+    with pytest.raises(ValueError, match="one-hot"):
+        sp.AA.translate(rag, nuc_alphabet=sp.DNA, validate=True)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pixi run -e dev pytest tests/test_translate.py::test_translate_ohe_validate_raises_multihot -v`
+Expected: FAIL — currently no OHE validation, so `translate` returns instead of raising (the multi-hot row decodes silently).
+
+- [ ] **Step 3: Add the `_check_ohe_rows` helper**
+
+Add as a method on `AminoAlphabet`, next to `_check_nuc_bytes`:
+
+```python
+    def _check_ohe_rows(self, data: NDArray[np.uint8], n_nuc: int) -> None:
+        """Raise ``ValueError`` unless every row of OHE ``data`` (alphabet axis
+        is axis 1 of the packed flat buffer) is exactly one-hot over ``n_nuc``
+        nucleotides. Used by ``translate(validate=True)`` for OHE Ragged input.
+
+        Required because decoding maps an all-zero row to the unknown sentinel
+        but a *multi-hot* row silently resolves to a real nucleotide — so a
+        decode-then-membership check would not catch it.
+        """
+        if data.shape[1] != n_nuc:
+            raise ValueError(
+                f"translate(validate=True): OHE width {data.shape[1]} does not "
+                f"match nucleotide alphabet size {n_nuc}."
+            )
+        sums = data.sum(axis=1, dtype=np.int64)
+        if not bool((sums == 1).all()):
+            raise ValueError(
+                "translate(validate=True): every OHE row must be one-hot "
+                "(exactly one 1 per nucleotide position)."
+            )
+```
+
+- [ ] **Step 4: Call the check in the `is_ohe` branch**
+
+In the Ragged branch, the `is_ohe` arm (currently lines 430-435) becomes:
+
+```python
+        if is_ohe:
+            if nuc_alphabet is None:
+                raise ValueError("nuc_alphabet is required for OHE Ragged input.")
+            if validate:
+                self._check_ohe_rows(seqs.data, len(nuc_alphabet.array))
+            nuc_bytes_flat: NDArray[np.bytes_] = nuc_alphabet.decode_ohe(  # type: ignore[union-attr]
+                seqs.data, ohe_axis=-1
+            )
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `pixi run -e dev pytest tests/test_translate.py -q`
+Expected: PASS — the three OHE validation tests pass; existing tests stay green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add python/seqpro/alphabets/_alphabets.py tests/test_translate.py
+git commit -m "feat(translate): validate OHE inputs are one-hot"
+```
+
+---
+
+### Task 5: Route the Ragged path through the LUT
+
+**Files:**
+- Modify: `python/seqpro/alphabets/_alphabets.py` (Ragged kernel call, currently lines 444-458)
+- Test: `tests/test_translate.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_translate.py`:
+
+```python
+def test_translate_ragged_uses_lut_matches_biopython():
+    """Ragged path (now LUT-routed for the standard alphabet) matches BioPython."""
+    rng = np.random.default_rng(7)
+    seq = "".join(rng.choice(list("ACGT"), size=300))
+    rag = _make_ragged_bytes(seq)
+    out = sp.AA.translate(rag)
+    expected = sp.cast_seqs(str(translate(seq)))
+    np.testing.assert_array_equal(_rag_bytes_to_array(out[0]), expected)
+
+
+def test_translate_ragged_fallback_for_nonstandard_alphabet():
+    """Non-ACGT alphabet has codon_lut=None → Ragged path uses the scan fallback."""
+    alpha = sp.AminoAlphabet(["AUG", "UAA"], ["M", "*"])
+    assert alpha.codon_lut is None
+    data = np.array(list("AUGUAA"), dtype="S1")
+    rag = Ragged.from_lengths(data, np.array([6]))
+    out = alpha.translate(rag)
+    np.testing.assert_array_equal(_rag_bytes_to_array(out[0]), sp.cast_seqs("M*"))
+```
+
+- [ ] **Step 2: Run tests to verify status**
+
+Run: `pixi run -e dev pytest tests/test_translate.py::test_translate_ragged_fallback_for_nonstandard_alphabet -v`
+Expected: PASS already (fallback path exists). The LUT-routing change is verified by the full suite in Step 4 — the `match_biopython` test passes before and after, but only exercises the LUT branch after the change. Both tests are committed now so the behavior is locked in.
+
+- [ ] **Step 3: Add the LUT branch to the Ragged kernel call**
+
+Replace the `if total > 0:` block (currently lines 444-458):
+
+```python
+        if total > 0:
+            codons = np.lib.stride_tricks.sliding_window_view(
+                nuc_bytes_flat, codon_size, axis=0
+            )
+            # sliding_window_view appends window axis at end → slice axis 0 by codon_size
+            codons = codons[::codon_size]
+            # codons shape: (num_codons, *trailing, codon_size); codon axis is last
+            translated_flat: NDArray[np.bytes_] = gufunc_translate(
+                codons.view(np.uint8),
+                self.codon_array.view(np.uint8),
+                self.aa_array.view(np.uint8),
+                axes=[-1, (-2, -1), (-1), ()],  # type: ignore
+            ).view("S1")  # (num_codons, *trailing)
+        else:
+            translated_flat = np.empty((0, *trailing), dtype="S1")
+```
+
+with:
+
+```python
+        if total > 0:
+            codons = np.lib.stride_tricks.sliding_window_view(
+                nuc_bytes_flat, codon_size, axis=0
+            )
+            # sliding_window_view appends window axis at end → slice axis 0 by codon_size
+            codons = codons[::codon_size]
+            # codons shape: (num_codons, *trailing, codon_size); codon axis is last
+            translated_flat: NDArray[np.bytes_]
+            if self.codon_lut is not None:
+                translated_flat = gufunc_translate_lut(
+                    codons.view(np.uint8),
+                    self.codon_lut,
+                    axes=[-1, -1, ()],  # type: ignore
+                ).view("S1")  # (num_codons, *trailing)
+            else:
+                translated_flat = gufunc_translate(
+                    codons.view(np.uint8),
+                    self.codon_array.view(np.uint8),
+                    self.aa_array.view(np.uint8),
+                    axes=[-1, (-2, -1), (-1), ()],  # type: ignore
+                ).view("S1")  # (num_codons, *trailing)
+        else:
+            translated_flat = np.empty((0, *trailing), dtype="S1")
+```
+
+- [ ] **Step 4: Run the full translate suite**
+
+Run: `pixi run -e dev pytest tests/test_translate.py -q`
+Expected: PASS — all Ragged tests (bytes basic, truncate-stop variants, OHE) and the two new tests pass, confirming the LUT path produces identical results to the former scan path.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/seqpro/alphabets/_alphabets.py tests/test_translate.py
+git commit -m "perf(translate): route Ragged path through codon LUT"
+```
+
+---
+
+### Task 6: Remove hardware-specific speed claims from docstrings; rename the bench file
+
+**Files:**
+- Modify: `python/seqpro/_numba.py` (`gufunc_translate` docstring ~line 121; `gufunc_translate_lut` docstring ~lines 156-189)
+- Rename + Modify: `tests/test_translate_lut_bench.py` → `tests/bench_translate_lut.py`
+
+- [ ] **Step 1: Soften the `gufunc_translate` docstring**
+
+In `python/seqpro/_numba.py`, the `gufunc_translate` docstring opening (added by PR #35) currently reads:
+
+```python
+    """Translate k-mers into amino acids via O(n) linear scan.
+
+    Generic fallback for non-standard alphabets where the codon length
+    differs from 3. For standard genetic-code translation (k=3), prefer
+    :func:`gufunc_translate_lut` — orders of magnitude faster via O(1)
+    table lookup.
+```
+
+Replace with:
+
+```python
+    """Translate k-mers into amino acids via an O(n) linear scan.
+
+    Generic fallback for non-standard alphabets (codon length other than 3,
+    or extended/IUPAC characters). For the standard genetic code (k=3, ACGT),
+    ``AminoAlphabet.translate`` automatically uses the O(1)
+    :func:`gufunc_translate_lut` path instead.
+```
+
+- [ ] **Step 2: Rewrite the `gufunc_translate_lut` docstring without speed claims**
+
+Replace the `gufunc_translate_lut` docstring (currently lines 156-189, the triple-quoted block) with:
+
+```python
+    """Translate a 3-codon to its amino acid via an O(1) lookup table.
+
+    Selected automatically by ``AminoAlphabet.translate`` for the standard
+    genetic code (k=3, ACGT); non-standard alphabets use
+    :func:`gufunc_translate` instead.
+
+    The LUT is indexed by ``_pack_codon_index``, which hashes each nucleotide's
+    ASCII byte with ``(byte >> 1) & 3`` — a bijection on ``{A, C, G, T}`` — and
+    packs the three 2-bit codes into a 6-bit index in ``[0, 63]``. The
+    64-element ``codon_lut`` (built by ``AminoAlphabet`` at construction) returns
+    the amino-acid byte for that index.
+
+    Parameters
+    ----------
+    seq_kmers
+        A 3-codon as ASCII bytes (e.g. ``[65, 84, 71]`` = ``"ATG"``).
+    codon_lut
+        64-byte LUT, built by ``AminoAlphabet`` at construction time.
+    res
+        Output buffer.
+    """
+```
+
+- [ ] **Step 3: Rename the benchmark file and strip its speed claim**
+
+Run:
+
+```bash
+git mv tests/test_translate_lut_bench.py tests/bench_translate_lut.py
+```
+
+Then in `tests/bench_translate_lut.py`, replace the module docstring (currently the opening triple-quoted block) with:
+
+```python
+"""Microbench: O(64) linear scan vs O(1) LUT in ``AminoAlphabet.translate``.
+
+Not collected by pytest (filename is not ``test_*``). Run explicitly to measure
+the speedup on your hardware::
+
+    python tests/bench_translate_lut.py
+
+Speedups are data- and hardware-dependent; this script reports measured numbers
+rather than asserting a fixed multiplier.
+"""
+```
+
+- [ ] **Step 4: Verify pytest no longer collects the bench and the suite passes**
+
+Run: `pixi run -e dev pytest tests/ -q --collect-only -k bench_translate_lut`
+Expected: no tests collected (0 items) — the bench is excluded.
+
+Run: `pixi run -e dev pytest tests/test_translate.py -q`
+Expected: PASS.
+
+Run (sanity-check the bench still executes as a script): `pixi run -e dev python tests/bench_translate_lut.py`
+Expected: prints timing lines and exits 0 (its `assert n_diff == 0` holds).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/seqpro/_numba.py tests/bench_translate_lut.py
+git commit -m "docs(translate): remove hardware-specific speedup claims; rename bench"
+```
+
+---
+
+### Task 7: Document the `validate` flag in the seqpro skill
+
+**Files:**
+- Modify: `skills/seqpro/SKILL.md`
+
+- [ ] **Step 1: Add a note about `validate`**
+
+In `skills/seqpro/SKILL.md`, directly after the alphabets bullet (line 25, the `Alphabets are singletons` line), add:
+
+```markdown
+- **`AminoAlphabet.translate(seqs, ..., validate=False)`**: translates nucleotides → amino acids. Pass `validate=True` to raise on any input outside the alphabet — non-ACGT bytes (lowercase, `N`, IUPAC codes) for string/byte input, or any non-one-hot row for OHE input. When `validate=True` returns without raising, the translation is guaranteed exact; the default `validate=False` skips the check for speed and treats out-of-alphabet input as undefined.
+```
+
+- [ ] **Step 2: Verify the skill mentions match the implemented signature**
+
+Run: `grep -n "validate" skills/seqpro/SKILL.md`
+Expected: shows the new line referencing `validate=False`, matching the `translate` signature from Task 3.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/seqpro/SKILL.md
+git commit -m "docs: document translate validate flag in seqpro skill"
+```
+
+---
+
+### Task 8: Final full-suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the entire test suite**
+
+Run: `pixi run -e dev pytest tests/ -q`
+Expected: all tests pass (the PR #35 baseline of 260 passed + the new tests added here), no errors, no unexpected collection of the bench file.
+
+- [ ] **Step 2: Lint and format**
+
+Run:
+```bash
+pixi run -e dev ruff check python/ tests/
+pixi run -e dev ruff format --check python/ tests/
+```
+Expected: no lint errors; formatting clean (run `ruff format python/ tests/` to fix if needed, then re-commit).
+
+- [ ] **Step 3: Confirm the branch is ready**
+
+Run: `git log --oneline 779bd97..HEAD`
+Expected: the spec commit plus the seven task commits, all conventional-commit formatted.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `validate` flag (byte + OHE) → Tasks 3, 4. ✓
+- Ragged path through LUT → Task 5. ✓
+- Single source of truth for bit-pack → Task 1. ✓
+- Predicate instead of try/except + honest `'X'` sentinel → Task 2. ✓
+- Remove speed claims from docstrings → Task 6. ✓
+- Rename bench out of pytest collection → Task 6. ✓
+- SKILL.md update → Task 7. ✓
+- Default path zero-overhead (validate defaults False) → Task 3. ✓
+- `feat:` overall (commit types: refactor/feat/perf/docs across tasks; PR-level is feat) → consistent with versioning section of spec. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every command has expected output. ✓
+
+**Type/name consistency:** `_pack_codon_index` (Task 1) used in Tasks 1, 2, test code; `_can_build_lut` (Task 2); `_valid_nuc_bytes` / `_check_nuc_bytes` (Task 3); `_check_ohe_rows` (Task 4) — names identical across all references. `validate` keyword added to all three overloads + impl (Task 3). ✓

--- a/docs/superpowers/specs/2026-05-28-translate-lut-and-validation-design.md
+++ b/docs/superpowers/specs/2026-05-28-translate-lut-and-validation-design.md
@@ -1,0 +1,149 @@
+# Design: codon→AA LUT completion + optional input validation
+
+Date: 2026-05-28
+Status: Approved (pending written-spec review)
+Scope: hardening and completing PR #35 (`perf(translate): O(1) LUT codon→AA lookup`)
+
+## Problem
+
+PR #35 added an O(1) lookup-table (LUT) path for `AminoAlphabet.translate` on the
+standard genetic code. Review surfaced four issues:
+
+1. **Silent mistranslation of non-ACGT input.** The LUT index hash
+   `(byte >> 1) & 3` is a bijection only on `{A, C, G, T}`. Every other byte
+   (lowercase `acgt`, `N`, IUPAC ambiguity codes, arbitrary ASCII) aliases onto
+   one of the four buckets and is silently translated as if it were a standard
+   nucleotide. The old linear-scan path left such cases as uninitialized output
+   buffer (garbage). Neither is correct; there is no way for a caller to get a
+   guarantee that input was valid.
+2. **The Ragged path was not optimized.** Only the dense/non-Ragged branch was
+   routed through the LUT. The motivating workload (genome-scale, variable-length
+   sequences) flows through the Ragged branch, which still used the slow scan.
+3. **Maintainability / clarity smells.** The bit-pack logic is duplicated in
+   Python (`_build_translate_lut`) and Numba (`gufunc_translate_lut`) and must be
+   kept in sync by hand; LUT-building used control-flow-by-exception; docstrings
+   carried hardware-specific speedup numbers; the `'X'` sentinel comment was
+   misleading; a benchmark file was named `test_*` and so was collected by pytest.
+
+## Goals
+
+- Give callers a way to guarantee valid input: a `validate` flag that raises on
+  any out-of-alphabet input, so that **if `validate=True` returns without
+  raising, the translation is exact**.
+- Route the Ragged path through the LUT for standard alphabets.
+- Remove the duplication and clarity smells.
+- Keep the default path zero-overhead (no behavior change for existing valid
+  ACGT callers).
+
+## Non-goals
+
+- Changing translation semantics for valid ACGT k=3 input (output stays
+  bit-for-bit identical).
+- Auto-uppercasing or coercing input. `validate` reports problems; it does not
+  silently fix them.
+- Validating codon-table *completeness* for arbitrary custom alphabets.
+  `validate` checks nucleotide membership; for the standard genetic code (the
+  only complete-by-construction case) that is sufficient for exactness.
+
+## Versioning
+
+Adding `validate` is a new public capability → conventional-commit type is
+`feat(translate):` → **MINOR** bump under the project's pre-1.0 semver
+(`0.x` feat → `0.(x+1).0`). This was explicitly chosen over splitting `validate`
+into a separate PR to keep the change in one place.
+
+## Design
+
+### 1. `validate: bool = False` on `AminoAlphabet.translate`
+
+- Add as a keyword-only argument to every `translate` overload and the
+  implementation. Default `False` preserves the zero-overhead fast path.
+- At `AminoAlphabet.__init__`, precompute once:
+  - `self._valid_nuc_bytes`: the unique nucleotide bytes across all `codons`
+    (for standard AA → `{65, 67, 71, 84}` = `ACGT`), as a small `uint8` array.
+- When `validate=True`, run a pre-check **before** either kernel, independent of
+  whether the LUT or fallback runs:
+  - **Byte input (dense and Ragged-bytes):** `np.isin(buf.view(np.uint8),
+    self._valid_nuc_bytes)`; if any element is out of set, raise `ValueError`
+    naming the offending unique characters (decoded for readability).
+  - **OHE Ragged input:** a structural one-hot check on `seqs.data` over the
+    alphabet axis (axis 1 in the packed flat buffer): every row must have
+    `sum == 1` (for non-negative `uint8` this is exactly one-hot), and the
+    alphabet-axis width must equal the nucleotide alphabet size. Raise
+    `ValueError` otherwise. This is required because `gufunc_ohe_char_idx`
+    (`_numba.py:39`) only maps all-zero rows to the unknown sentinel; a
+    **multi-hot** row silently resolves to a real nucleotide, so a
+    decode-then-membership check would not catch it.
+- **Guarantee:** `validate=True` returning normally ⇒ every nucleotide is in the
+  alphabet ⇒ on the standard genetic code the LUT result is exact. `validate=False`
+  (default) ⇒ behavior unchanged from PR #35; invalid input is undefined on the
+  LUT path (documented).
+
+### 2. Route the Ragged path through the LUT
+
+In the Ragged branch (`_alphabets.py:384`, after any OHE decode), mirror the dense
+branch: when `self.codon_lut is not None`, call `gufunc_translate_lut(codons.view(
+np.uint8), self.codon_lut, axes=[-1, -1, ()])`; otherwise fall back to
+`gufunc_translate`.
+
+### 3. Single source of truth for the bit-pack
+
+Add a module-level `@nb.njit` helper:
+
+```python
+def _pack_codon_index(b0, b1, b2):
+    return (((b0 >> 1) & 3) << 4) | (((b1 >> 1) & 3) << 2) | ((b2 >> 1) & 3)
+```
+
+Call it from both `gufunc_translate_lut` (Numba) and `_build_translate_lut`
+(Python — njit functions are callable from the interpreter). The runtime lookup
+and the table construction can no longer drift out of sync.
+
+### 4. Predicate instead of try/except; honest `'X'` sentinel
+
+- Replace the `try/except ValueError` in `__init__` with an explicit predicate
+  `_can_build_lut(codons)` → `all(len(c) == 3 and set(c) <= set("ACGT") for c in
+  codons)`. If true, build the LUT; else `self.codon_lut = None`.
+- `_build_translate_lut` no longer raises (the predicate gates it).
+- Keep the `np.full(64, ord("X"))` initialization: it is a genuine safety net for
+  a *partial* ACGT/k=3 alphabet (a missing codon → `'X'`, not garbage). Fix the
+  comment, which wrongly implied the sentinel is load-bearing for the complete
+  64-codon standard alphabet (where every slot is overwritten).
+
+### 5. Docstrings carry no speed claims
+
+Remove every concrete multiplier from `gufunc_translate_lut`, `_build_translate_lut`,
+and the benchmark module docstring. Docstrings describe behavior and guide usage
+(the LUT path is selected automatically by `AminoAlphabet.translate` on the
+standard genetic code; the linear scan is the fallback for non-standard
+alphabets). Speedups are data- and hardware-dependent and belong only in the
+benchmark's runtime output.
+
+### 6. Benchmark file
+
+Rename `tests/test_translate_lut_bench.py` → `tests/bench_translate_lut.py` so
+pytest's default `test_*` collection skips it. It remains runnable as
+`python tests/bench_translate_lut.py`. (No `testpaths` override exists in
+`pyproject.toml`, so renaming is sufficient to exclude it.)
+
+### 7. SKILL.md
+
+Per CLAUDE.md, a public signature change requires a same-PR skill update. Add a
+short note for `AminoAlphabet.translate(..., validate=False)` documenting the flag
+and its guarantee.
+
+## Testing
+
+- **Retain** the existing equality, hypothesis fuzz, and BioPython cross-validation
+  tests; they now also exercise the Ragged LUT path.
+- `validate=True` raises on lowercase / `N` / non-ACGT input — dense and Ragged.
+- `validate=True` passes on valid ACGT input; `validate=False` never raises.
+- OHE Ragged: `validate=True` raises on a multi-hot row and on an all-zero row;
+  passes on valid one-hot.
+- Ragged LUT output == Ragged fallback output == dense output (bitwise).
+- A non-standard alphabet (k≠3 or non-ACGT codon) → `codon_lut is None`, fallback
+  path used, results still correct.
+
+## Commit
+
+`feat(translate): O(1) codon→AA LUT for dense and Ragged paths + optional input validation`

--- a/python/seqpro/_numba.py
+++ b/python/seqpro/_numba.py
@@ -118,12 +118,12 @@ def gufunc_translate(
     kmer_values: NDArray[np.uint8],
     res: NDArray[np.uint8] | None = None,
 ) -> NDArray[np.uint8]:  # type: ignore
-    """Translate k-mers into amino acids via O(n) linear scan.
+    """Translate k-mers into amino acids via an O(n) linear scan.
 
-    Generic fallback for non-standard alphabets where the codon length
-    differs from 3. For standard genetic-code translation (k=3), prefer
-    :func:`gufunc_translate_lut` — orders of magnitude faster via O(1)
-    table lookup.
+    Generic fallback for non-standard alphabets (codon length other than 3,
+    or extended/IUPAC characters). For the standard genetic code (k=3, ACGT),
+    ``AminoAlphabet.translate`` automatically uses the O(1)
+    :func:`gufunc_translate_lut` path instead.
 
     Parameters
     ----------
@@ -169,25 +169,17 @@ def gufunc_translate_lut(
     codon_lut: NDArray[np.uint8],
     res: NDArray[np.uint8] | None = None,
 ) -> NDArray[np.uint8]:  # type: ignore
-    """Translate a 3-codon to its amino acid via O(1) lookup table.
+    """Translate a 3-codon to its amino acid via an O(1) lookup table.
 
-    Replaces the O(64) linear scan in :func:`gufunc_translate` with a
-    single table dereference, exploiting that DNA's ASCII bytes already
-    encode a 2-bit-per-nucleotide hash via ``(byte >> 1) & 3``:
+    Selected automatically by ``AminoAlphabet.translate`` for the standard
+    genetic code (k=3, ACGT); non-standard alphabets use
+    :func:`gufunc_translate` instead.
 
-    - ``'A'`` (65) → 0
-    - ``'C'`` (67) → 1
-    - ``'T'`` (84) → 2
-    - ``'G'`` (71) → 3
-
-    Any permutation of {A, C, G, T} → {0, 1, 2, 3} works equally well,
-    so the LUT just needs to be built with the same bit-packing the
-    runtime uses. Indices are packed
-    ``(n0 << 4) | (n1 << 2) | n2`` for a 6-bit index in ``[0, 63]``;
-    the 64-element ``codon_lut`` returns the AA byte for each.
-
-    Only valid for ``k == 3`` (standard genetic code). Non-standard
-    alphabets keep using :func:`gufunc_translate`.
+    The LUT is indexed by ``_pack_codon_index``, which hashes each nucleotide's
+    ASCII byte with ``(byte >> 1) & 3`` — a bijection on ``{A, C, G, T}`` — and
+    packs the three 2-bit codes into a 6-bit index in ``[0, 63]``. The
+    64-element ``codon_lut`` (built by ``AminoAlphabet`` at construction) returns
+    the amino-acid byte for that index.
 
     Parameters
     ----------
@@ -197,12 +189,6 @@ def gufunc_translate_lut(
         64-byte LUT, built by ``AminoAlphabet`` at construction time.
     res
         Output buffer.
-
-    Notes
-    -----
-    Speedup vs :func:`gufunc_translate`: ~20-50× on large arrays. The
-    LUT fits in L1 cache (64 bytes); the lookup is two integer shifts +
-    two ors + one array dereference per codon.
     """
     res[0] = codon_lut[_pack_codon_index(seq_kmers[0], seq_kmers[1], seq_kmers[2])]
 

--- a/python/seqpro/_numba.py
+++ b/python/seqpro/_numba.py
@@ -142,6 +142,22 @@ def gufunc_translate(
             break
 
 
+@nb.njit(cache=True)
+def _pack_codon_index(b0, b1, b2):
+    """Pack a 3-codon's ASCII bytes into a 6-bit LUT index in ``[0, 63]``.
+
+    Uses the 2-bit-per-nucleotide hash ``(byte >> 1) & 3``, a bijection on
+    ``{A, C, G, T}``. This is the single source of truth for the codon→index
+    mapping: both the runtime lookup (:func:`gufunc_translate_lut`) and the
+    table builder (``_build_translate_lut``) call it, so they cannot drift
+    out of sync.
+    """
+    n0 = (b0 >> 1) & 3
+    n1 = (b1 >> 1) & 3
+    n2 = (b2 >> 1) & 3
+    return (n0 << 4) | (n1 << 2) | n2
+
+
 @nb.guvectorize(
     ["(u1[:], u1[:], u1[:])"],
     "(k),(m)->()",
@@ -188,11 +204,7 @@ def gufunc_translate_lut(
     LUT fits in L1 cache (64 bytes); the lookup is two integer shifts +
     two ors + one array dereference per codon.
     """
-    n0 = (seq_kmers[0] >> 1) & 3
-    n1 = (seq_kmers[1] >> 1) & 3
-    n2 = (seq_kmers[2] >> 1) & 3
-    idx = (n0 << 4) | (n1 << 2) | n2
-    res[0] = codon_lut[idx]
+    res[0] = codon_lut[_pack_codon_index(seq_kmers[0], seq_kmers[1], seq_kmers[2])]
 
 
 @nb.guvectorize(

--- a/python/seqpro/_numba.py
+++ b/python/seqpro/_numba.py
@@ -118,7 +118,12 @@ def gufunc_translate(
     kmer_values: NDArray[np.uint8],
     res: NDArray[np.uint8] | None = None,
 ) -> NDArray[np.uint8]:  # type: ignore
-    """Translate 3-mers into amino acids.
+    """Translate k-mers into amino acids via O(n) linear scan.
+
+    Generic fallback for non-standard alphabets where the codon length
+    differs from 3. For standard genetic-code translation (k=3), prefer
+    :func:`gufunc_translate_lut` — orders of magnitude faster via O(1)
+    table lookup.
 
     Parameters
     ----------
@@ -135,6 +140,59 @@ def gufunc_translate(
         if (seq_kmers == kmer_keys[i]).all():
             res[0] = kmer_values[i]  # type: ignore
             break
+
+
+@nb.guvectorize(
+    ["(u1[:], u1[:], u1[:])"],
+    "(k),(m)->()",
+    target="parallel",
+    cache=True,
+)
+def gufunc_translate_lut(
+    seq_kmers: NDArray[np.uint8],
+    codon_lut: NDArray[np.uint8],
+    res: NDArray[np.uint8] | None = None,
+) -> NDArray[np.uint8]:  # type: ignore
+    """Translate a 3-codon to its amino acid via O(1) lookup table.
+
+    Replaces the O(64) linear scan in :func:`gufunc_translate` with a
+    single table dereference, exploiting that DNA's ASCII bytes already
+    encode a 2-bit-per-nucleotide hash via ``(byte >> 1) & 3``:
+
+    - ``'A'`` (65) → 0
+    - ``'C'`` (67) → 1
+    - ``'T'`` (84) → 2
+    - ``'G'`` (71) → 3
+
+    Any permutation of {A, C, G, T} → {0, 1, 2, 3} works equally well,
+    so the LUT just needs to be built with the same bit-packing the
+    runtime uses. Indices are packed
+    ``(n0 << 4) | (n1 << 2) | n2`` for a 6-bit index in ``[0, 63]``;
+    the 64-element ``codon_lut`` returns the AA byte for each.
+
+    Only valid for ``k == 3`` (standard genetic code). Non-standard
+    alphabets keep using :func:`gufunc_translate`.
+
+    Parameters
+    ----------
+    seq_kmers
+        A 3-codon as ASCII bytes (e.g. ``[65, 84, 71]`` = ``"ATG"``).
+    codon_lut
+        64-byte LUT, built by ``AminoAlphabet`` at construction time.
+    res
+        Output buffer.
+
+    Notes
+    -----
+    Speedup vs :func:`gufunc_translate`: ~20-50× on large arrays. The
+    LUT fits in L1 cache (64 bytes); the lookup is two integer shifts +
+    two ors + one array dereference per codon.
+    """
+    n0 = (seq_kmers[0] >> 1) & 3
+    n1 = (seq_kmers[1] >> 1) & 3
+    n2 = (seq_kmers[2] >> 1) & 3
+    idx = (n0 << 4) | (n1 << 2) | n2
+    res[0] = codon_lut[idx]
 
 
 @nb.guvectorize(

--- a/python/seqpro/alphabets/_alphabets.py
+++ b/python/seqpro/alphabets/_alphabets.py
@@ -504,12 +504,20 @@ class AminoAlphabet:
             # sliding_window_view appends window axis at end → slice axis 0 by codon_size
             codons = codons[::codon_size]
             # codons shape: (num_codons, *trailing, codon_size); codon axis is last
-            translated_flat: NDArray[np.bytes_] = gufunc_translate(
-                codons.view(np.uint8),
-                self.codon_array.view(np.uint8),
-                self.aa_array.view(np.uint8),
-                axes=[-1, (-2, -1), (-1), ()],  # type: ignore
-            ).view("S1")  # (num_codons, *trailing)
+            translated_flat: NDArray[np.bytes_]
+            if self.codon_lut is not None:
+                translated_flat = gufunc_translate_lut(
+                    codons.view(np.uint8),
+                    self.codon_lut,
+                    axes=[-1, -1, ()],  # type: ignore
+                ).view("S1")  # (num_codons, *trailing)
+            else:
+                translated_flat = gufunc_translate(
+                    codons.view(np.uint8),
+                    self.codon_array.view(np.uint8),
+                    self.aa_array.view(np.uint8),
+                    axes=[-1, (-2, -1), (-1), ()],  # type: ignore
+                ).view("S1")  # (num_codons, *trailing)
         else:
             translated_flat = np.empty((0, *trailing), dtype="S1")
 

--- a/python/seqpro/alphabets/_alphabets.py
+++ b/python/seqpro/alphabets/_alphabets.py
@@ -9,6 +9,7 @@ from numpy.typing import NDArray
 
 from .._numba import (
     _nb_find_stop_ends,
+    _pack_codon_index,
     gufunc_complement_bytes,
     gufunc_translate,
     gufunc_translate_lut,
@@ -259,10 +260,7 @@ def _build_translate_lut(
         for c in (codon[0], codon[1], codon[2]):
             if c not in "ACGT":
                 raise ValueError(f"LUT path requires ACGT-only codons; got {codon!r}")
-        n0 = (n0_byte >> 1) & 3
-        n1 = (n1_byte >> 1) & 3
-        n2 = (n2_byte >> 1) & 3
-        idx = (n0 << 4) | (n1 << 2) | n2
+        idx = _pack_codon_index(n0_byte, n1_byte, n2_byte)
         lut[idx] = ord(aa)
     return lut
 

--- a/python/seqpro/alphabets/_alphabets.py
+++ b/python/seqpro/alphabets/_alphabets.py
@@ -221,46 +221,45 @@ class NucleotideAlphabet:
             raise ValueError("Invalid sequence type.")
 
 
+def _can_build_lut(codons: list[str]) -> bool:
+    """True when the standard O(1) LUT path applies: every codon is length-3
+    and uses only the four standard nucleotides A, C, G, T. Non-standard
+    alphabets (different codon size or extended/IUPAC characters) use the
+    generic :func:`gufunc_translate` scan instead."""
+    return all(len(c) == 3 and set(c) <= set("ACGT") for c in codons)
+
+
 def _build_translate_lut(
     codons: list[str], amino_acids: list[str]
 ) -> NDArray[np.uint8]:
     """Build the 64-entry codon→AA lookup table consumed by ``gufunc_translate_lut``.
 
-    The index for codon ``[n0, n1, n2]`` (ASCII bytes) is
-    ``((n0 >> 1) & 3) << 4 | ((n1 >> 1) & 3) << 2 | ((n2 >> 1) & 3)`` —
-    the same bit-packing the runtime uses. Codons not present in
-    ``codons`` (e.g. ambiguous IUPAC codes) get ``'X'`` (78) as a safe
-    "unknown amino acid" sentinel.
+    The packed index for each codon is computed by ``_pack_codon_index`` — the
+    same hash the runtime uses — so the table and the lookup cannot drift.
+
+    Callers must gate construction with ``_can_build_lut`` (length-3, ACGT-only
+    codons); this function does not re-validate. The table is initialised to the
+    ``'X'`` (unknown amino acid) byte so that a *partial* standard alphabet — one
+    that is ACGT/k=3 but omits some of the 64 codons — resolves missing codons to
+    ``'X'`` rather than uninitialised memory. For the complete standard genetic
+    code all 64 slots are overwritten.
 
     Parameters
     ----------
     codons
-        List of 3-character DNA strings (uppercase ACGT only).
+        List of length-3 DNA strings (uppercase ACGT).
     amino_acids
-        List of 1-character amino-acid strings, aligned with ``codons``.
+        List of single-character amino-acid strings, aligned with ``codons``.
 
     Returns
     -------
     NDArray[np.uint8]
-        Shape ``(64,)``. ``lut[idx]`` is the AA byte for the codon at
-        packed index ``idx``.
-
-    Raises
-    ------
-    ValueError
-        If any codon contains a non-``ACGT`` character (the LUT
-        bit-packing only handles the 4 standard nucleotides; pass an
-        extended alphabet to the generic ``gufunc_translate`` path).
+        Shape ``(64,)``; ``lut[idx]`` is the AA byte for the codon at packed
+        index ``idx``.
     """
     lut = np.full(64, ord("X"), dtype=np.uint8)
     for codon, aa in zip(codons, amino_acids, strict=True):
-        if len(codon) != 3:
-            raise ValueError(f"LUT path requires k=3 codons; got {codon!r}")
-        n0_byte, n1_byte, n2_byte = ord(codon[0]), ord(codon[1]), ord(codon[2])
-        for c in (codon[0], codon[1], codon[2]):
-            if c not in "ACGT":
-                raise ValueError(f"LUT path requires ACGT-only codons; got {codon!r}")
-        idx = _pack_codon_index(n0_byte, n1_byte, n2_byte)
+        idx = _pack_codon_index(ord(codon[0]), ord(codon[1]), ord(codon[2]))
         lut[idx] = ord(aa)
     return lut
 
@@ -312,12 +311,11 @@ class AminoAlphabet:
 
         self.codon_to_aa = dict(zip(codons, amino_acids))
 
-        # Build the 64-entry O(1) lookup table when the alphabet is the
-        # standard ACGT × k=3 case; fall back to the generic linear-scan
-        # path for non-standard alphabets.
-        try:
+        # Build the 64-entry O(1) lookup table only for the standard ACGT × k=3
+        # case; non-standard alphabets use the generic linear-scan path.
+        if _can_build_lut(codons):
             self.codon_lut = _build_translate_lut(codons, amino_acids)
-        except ValueError:
+        else:
             self.codon_lut = None
 
     @overload

--- a/python/seqpro/alphabets/_alphabets.py
+++ b/python/seqpro/alphabets/_alphabets.py
@@ -11,6 +11,7 @@ from .._numba import (
     _nb_find_stop_ends,
     gufunc_complement_bytes,
     gufunc_translate,
+    gufunc_translate_lut,
     ufunc_comp_dna,
 )
 from .._utils import SeqType, StrSeqType, array_slice, cast_seqs, check_axes, is_dtype
@@ -219,12 +220,64 @@ class NucleotideAlphabet:
             raise ValueError("Invalid sequence type.")
 
 
+def _build_translate_lut(
+    codons: list[str], amino_acids: list[str]
+) -> NDArray[np.uint8]:
+    """Build the 64-entry codon→AA lookup table consumed by ``gufunc_translate_lut``.
+
+    The index for codon ``[n0, n1, n2]`` (ASCII bytes) is
+    ``((n0 >> 1) & 3) << 4 | ((n1 >> 1) & 3) << 2 | ((n2 >> 1) & 3)`` —
+    the same bit-packing the runtime uses. Codons not present in
+    ``codons`` (e.g. ambiguous IUPAC codes) get ``'X'`` (78) as a safe
+    "unknown amino acid" sentinel.
+
+    Parameters
+    ----------
+    codons
+        List of 3-character DNA strings (uppercase ACGT only).
+    amino_acids
+        List of 1-character amino-acid strings, aligned with ``codons``.
+
+    Returns
+    -------
+    NDArray[np.uint8]
+        Shape ``(64,)``. ``lut[idx]`` is the AA byte for the codon at
+        packed index ``idx``.
+
+    Raises
+    ------
+    ValueError
+        If any codon contains a non-``ACGT`` character (the LUT
+        bit-packing only handles the 4 standard nucleotides; pass an
+        extended alphabet to the generic ``gufunc_translate`` path).
+    """
+    lut = np.full(64, ord("X"), dtype=np.uint8)
+    for codon, aa in zip(codons, amino_acids, strict=True):
+        if len(codon) != 3:
+            raise ValueError(f"LUT path requires k=3 codons; got {codon!r}")
+        n0_byte, n1_byte, n2_byte = ord(codon[0]), ord(codon[1]), ord(codon[2])
+        for c in (codon[0], codon[1], codon[2]):
+            if c not in "ACGT":
+                raise ValueError(f"LUT path requires ACGT-only codons; got {codon!r}")
+        n0 = (n0_byte >> 1) & 3
+        n1 = (n1_byte >> 1) & 3
+        n2 = (n2_byte >> 1) & 3
+        idx = (n0 << 4) | (n1 << 2) | n2
+        lut[idx] = ord(aa)
+    return lut
+
+
 class AminoAlphabet:
     codons: list[str]
     amino_acids: list[str]
     codon_array: NDArray[np.bytes_]
     aa_array: NDArray[np.bytes_]
     codon_to_aa: dict[str, str]
+    codon_lut: NDArray[np.uint8] | None
+    """Pre-built 64-entry codon→AA LUT for the fast :func:`gufunc_translate_lut`
+    path. ``None`` for non-standard alphabets where the codon length isn't
+    3 or any codon contains a non-ACGT character — the generic
+    :func:`gufunc_translate` path runs in that case."""
 
     def __init__(self, codons: list[str], amino_acids: list[str]) -> None:
         """Construct an alphabet of amino acids and their mappings to codons.
@@ -260,6 +313,14 @@ class AminoAlphabet:
         self.aa_array = np.array(amino_acids, "S1")
 
         self.codon_to_aa = dict(zip(codons, amino_acids))
+
+        # Build the 64-entry O(1) lookup table when the alphabet is the
+        # standard ACGT × k=3 case; fall back to the generic linear-scan
+        # path for non-standard alphabets.
+        try:
+            self.codon_lut = _build_translate_lut(codons, amino_acids)
+        except ValueError:
+            self.codon_lut = None
 
     @overload
     def translate(
@@ -335,6 +396,12 @@ class AminoAlphabet:
                 seqs, window_shape=codon_size, axis=length_axis
             )
             codons = array_slice(codons, length_axis, slice(None, None, codon_size))
+            if self.codon_lut is not None:
+                return gufunc_translate_lut(
+                    codons.view(np.uint8),
+                    self.codon_lut,
+                    axes=[-1, -1, ()],  # type: ignore
+                ).view("S1")
             return gufunc_translate(
                 codons.view(np.uint8),
                 self.codon_array.view(np.uint8),

--- a/python/seqpro/alphabets/_alphabets.py
+++ b/python/seqpro/alphabets/_alphabets.py
@@ -275,6 +275,9 @@ class AminoAlphabet:
     path. ``None`` for non-standard alphabets where the codon length isn't
     3 or any codon contains a non-ACGT character — the generic
     :func:`gufunc_translate` path runs in that case."""
+    _valid_nuc_bytes: NDArray[np.uint8]
+    """Unique nucleotide bytes across all codons (e.g. ``ACGT`` for the standard
+    alphabet), used by ``translate(validate=True)`` to check string input."""
 
     def __init__(self, codons: list[str], amino_acids: list[str]) -> None:
         """Construct an alphabet of amino acids and their mappings to codons.
@@ -318,6 +321,22 @@ class AminoAlphabet:
         else:
             self.codon_lut = None
 
+        # Unique nucleotide bytes across all codons, for translate(validate=True).
+        nuc_chars = sorted({c for codon in codons for c in codon})
+        self._valid_nuc_bytes = np.array([ord(c) for c in nuc_chars], dtype=np.uint8)
+
+    def _check_nuc_bytes(self, buf: NDArray[np.uint8]) -> None:
+        """Raise ``ValueError`` if any byte in ``buf`` is outside the alphabet's
+        nucleotides. Used by ``translate(validate=True)`` for string input."""
+        ok = np.isin(buf, self._valid_nuc_bytes)
+        if not bool(ok.all()):
+            bad = np.unique(buf[~ok]).tobytes().decode("ascii", "replace")
+            allowed = self._valid_nuc_bytes.tobytes().decode("ascii")
+            raise ValueError(
+                f"translate(validate=True): input contains characters outside "
+                f"the alphabet {{{allowed}}}: found {bad!r}."
+            )
+
     @overload
     def translate(
         self,
@@ -326,6 +345,7 @@ class AminoAlphabet:
         *,
         nuc_alphabet: NucleotideAlphabet | None = None,
         truncate_stop: bool = False,
+        validate: bool = False,
     ) -> NDArray[np.bytes_]: ...
     @overload
     def translate(
@@ -335,6 +355,7 @@ class AminoAlphabet:
         *,
         nuc_alphabet: NucleotideAlphabet | None = None,
         truncate_stop: bool = False,
+        validate: bool = False,
     ) -> Ragged[np.bytes_]: ...
     @overload
     def translate(
@@ -344,6 +365,7 @@ class AminoAlphabet:
         *,
         nuc_alphabet: NucleotideAlphabet,
         truncate_stop: bool = False,
+        validate: bool = False,
     ) -> Ragged[np.uint8]: ...
     def translate(
         self,
@@ -352,6 +374,7 @@ class AminoAlphabet:
         *,
         nuc_alphabet: NucleotideAlphabet | None = None,
         truncate_stop: bool = False,
+        validate: bool = False,
     ) -> NDArray[np.bytes_] | Ragged[np.bytes_] | Ragged[np.uint8]:
         """Translate nucleotide sequences to amino acids.
 
@@ -367,6 +390,11 @@ class AminoAlphabet:
         truncate_stop
             When True, each output sequence is truncated at the first stop codon
             (inclusive). Only valid for Ragged input. Default False.
+        validate
+            When True, raise ValueError if any input nucleotide is outside this
+            alphabet (e.g. lowercase, ``N``, or other non-ACGT bytes; for OHE
+            input, any row that is not exactly one-hot). When validation passes,
+            the translation is guaranteed exact. Default False (no checking).
 
         Returns
         -------
@@ -377,6 +405,8 @@ class AminoAlphabet:
         if not isinstance(seqs, Ragged):
             check_axes(seqs, length_axis, False)
             seqs = cast_seqs(seqs)
+            if validate:
+                self._check_nuc_bytes(seqs.view(np.uint8))
             codon_size = self.codon_array.shape[-1]
             if length_axis is None:
                 length_axis = -1
@@ -431,6 +461,8 @@ class AminoAlphabet:
             )
         else:
             nuc_bytes_flat = seqs.data
+            if validate:
+                self._check_nuc_bytes(nuc_bytes_flat.view(np.uint8))
 
         # Translate the entire flat buffer in one vectorized call. This is valid because
         # translation is invariant to splitting/concatenation when all lengths % codon_size == 0.

--- a/python/seqpro/alphabets/_alphabets.py
+++ b/python/seqpro/alphabets/_alphabets.py
@@ -337,6 +337,32 @@ class AminoAlphabet:
                 f"the alphabet {{{allowed}}}: found {bad!r}."
             )
 
+    def _check_ohe_rows(self, data: NDArray[np.uint8], n_nuc: int) -> None:
+        """Raise ``ValueError`` unless every row of OHE ``data`` (alphabet axis
+        is axis 1 of the packed flat buffer) is exactly one-hot over ``n_nuc``
+        nucleotides. Used by ``translate(validate=True)`` for OHE Ragged input.
+
+        Required because decoding maps an all-zero row to the unknown sentinel
+        but a *multi-hot* row silently resolves to a real nucleotide — so a
+        decode-then-membership check would not catch it.
+        """
+        if data.ndim != 2:
+            raise ValueError(
+                f"translate(validate=True): OHE data must be 2-D (total, n_nuc), "
+                f"got shape {data.shape!r}."
+            )
+        if data.shape[1] != n_nuc:
+            raise ValueError(
+                f"translate(validate=True): OHE width {data.shape[1]} does not "
+                f"match nucleotide alphabet size {n_nuc}."
+            )
+        sums = data.sum(axis=1, dtype=np.int64)
+        if not bool((sums == 1).all()):
+            raise ValueError(
+                "translate(validate=True): every OHE row must be one-hot "
+                "(exactly one 1 per nucleotide position)."
+            )
+
     @overload
     def translate(
         self,
@@ -456,6 +482,8 @@ class AminoAlphabet:
         if is_ohe:
             if nuc_alphabet is None:
                 raise ValueError("nuc_alphabet is required for OHE Ragged input.")
+            if validate:
+                self._check_ohe_rows(seqs.data, len(nuc_alphabet.array))
             nuc_bytes_flat: NDArray[np.bytes_] = nuc_alphabet.decode_ohe(  # type: ignore[union-attr]
                 seqs.data, ohe_axis=-1
             )

--- a/skills/seqpro/SKILL.md
+++ b/skills/seqpro/SKILL.md
@@ -23,6 +23,7 @@ Python/Rust package for fast biological-sequence processing. Python+NumPy+Numba 
 - **Axis arguments are required and explicit**: most functions take `length_axis` and (for OHE) `ohe_axis` as positional/keyword ints. Negative indices allowed. `check_axes()` validates and raises early — don't catch and paper over.
 - **No Python loops over sequences in library code.** Hot paths use NumPy, Numba kernels in `_numba.py`, or the Rust extension. If you're tempted to write a `for` over residues, look for an existing vectorized op or a Numba kernel first.
 - **Alphabets are singletons**: `sp.DNA`, `sp.RNA`, `sp.AA`. Construct custom ones via `sp.NucleotideAlphabet` / `sp.AminoAlphabet` (`python/seqpro/alphabets/_alphabets.py`).
+- **`AminoAlphabet.translate(seqs, ..., validate=False)`**: translates nucleotides → amino acids. Pass `validate=True` to raise on any input outside the alphabet — non-ACGT bytes (lowercase, `N`, IUPAC codes) for string/byte input, or any non-one-hot row for OHE input. When `validate=True` returns without raising, the translation is guaranteed exact; the default `validate=False` skips the check for speed and treats out-of-alphabet input as undefined.
 - **Transforms** (`python/seqpro/transforms/`) wrap functional ops as callables — use these in data pipelines instead of inline lambdas.
 
 ## Quick reference

--- a/tests/bench_translate_lut.py
+++ b/tests/bench_translate_lut.py
@@ -1,13 +1,12 @@
-"""Microbench: O(64) linear scan vs O(1) LUT in ``gufunc_translate``.
+"""Microbench: O(64) linear scan vs O(1) LUT in ``AminoAlphabet.translate``.
 
-Skipped under the default test selection; run explicitly with::
+Not collected by pytest (filename is not ``test_*``). Run explicitly to measure
+the speedup on your hardware::
 
-    python tests/test_translate_lut_bench.py
+    python tests/bench_translate_lut.py
 
-Expected speedup: 20-50× depending on CPU + cache effects. The LUT is
-64 bytes (fits in L1), the lookup is two shifts + two ors + one
-dereference per codon, while the original scan does up to 64 byte-array
-comparisons per codon.
+Speedups are data- and hardware-dependent; this script reports measured numbers
+rather than asserting a fixed multiplier.
 """
 
 from __future__ import annotations

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -305,3 +305,32 @@ def test_translate_ragged_bytes_validate_raises():
     rag = _make_ragged_bytes("ATGNNN")
     with pytest.raises(ValueError, match="outside the alphabet"):
         sp.AA.translate(rag, validate=True)
+
+
+def test_translate_ohe_validate_passes_valid():
+    ohe = sp.DNA.ohe(sp.cast_seqs("ATCGAT"))
+    rag = Ragged.from_lengths(ohe, np.array([6]))
+    # Should not raise.
+    sp.AA.translate(rag, nuc_alphabet=sp.DNA, validate=True)
+
+
+def test_translate_ohe_validate_raises_multihot():
+    ohe = sp.DNA.ohe(sp.cast_seqs("ATCGAT")).copy()
+    ohe[0, :] = 1  # multi-hot row (sum == 4)
+    rag = Ragged.from_lengths(ohe, np.array([6]))
+    with pytest.raises(ValueError, match="one-hot"):
+        sp.AA.translate(rag, nuc_alphabet=sp.DNA, validate=True)
+
+
+def test_translate_ohe_validate_raises_allzero():
+    ohe = sp.DNA.ohe(sp.cast_seqs("ATCGAT")).copy()
+    ohe[0, :] = 0  # all-zero row (sum == 0)
+    rag = Ragged.from_lengths(ohe, np.array([6]))
+    with pytest.raises(ValueError, match="one-hot"):
+        sp.AA.translate(rag, nuc_alphabet=sp.DNA, validate=True)
+
+
+def test_check_ohe_rows_raises_on_1d_data():
+    """A 1-D buffer (not (total, n_nuc)) yields a clear ValueError, not IndexError."""
+    with pytest.raises(ValueError, match="must be 2-D"):
+        sp.AA._check_ohe_rows(np.zeros(6, dtype=np.uint8), 4)

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -93,6 +93,18 @@ def test_lut_and_linear_scan_produce_identical_output():
     np.testing.assert_array_equal(actual, expected)
 
 
+def test_pack_codon_index_bijective_over_acgt():
+    """The 64 ACGT codons map to 64 distinct indices covering exactly [0, 63]."""
+    from seqpro._numba import _pack_codon_index
+
+    idxs = set()
+    for a in "ACGT":
+        for b in "ACGT":
+            for c in "ACGT":
+                idxs.add(int(_pack_codon_index(ord(a), ord(b), ord(c))))
+    assert idxs == set(range(64))
+
+
 def test_alphabet_translate_uses_lut_by_default():
     """``sp.AA.translate`` should now go through the LUT path on standard
     AA. Cross-validate against BioPython to confirm the LUT is correct."""

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -334,3 +334,23 @@ def test_check_ohe_rows_raises_on_1d_data():
     """A 1-D buffer (not (total, n_nuc)) yields a clear ValueError, not IndexError."""
     with pytest.raises(ValueError, match="must be 2-D"):
         sp.AA._check_ohe_rows(np.zeros(6, dtype=np.uint8), 4)
+
+
+def test_translate_ragged_uses_lut_matches_biopython():
+    """Ragged path (now LUT-routed for the standard alphabet) matches BioPython."""
+    rng = np.random.default_rng(7)
+    seq = "".join(rng.choice(list("ACGT"), size=300))
+    rag = _make_ragged_bytes(seq)
+    out = sp.AA.translate(rag)
+    expected = sp.cast_seqs(str(translate(seq)))
+    np.testing.assert_array_equal(_rag_bytes_to_array(out[0]), expected)
+
+
+def test_translate_ragged_fallback_for_nonstandard_alphabet():
+    """Non-ACGT alphabet has codon_lut=None → Ragged path uses the scan fallback."""
+    alpha = sp.AminoAlphabet(["AUG", "UAA"], ["M", "*"])
+    assert alpha.codon_lut is None
+    data = np.array(list("AUGUAA"), dtype="S1")
+    rag = Ragged.from_lengths(data, np.array([6]))
+    out = alpha.translate(rag)
+    np.testing.assert_array_equal(_rag_bytes_to_array(out[0]), sp.cast_seqs("M*"))

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -34,6 +34,76 @@ def test_gufunc_translate(
     np.testing.assert_array_equal(actual, desired)
 
 
+# --- LUT path tests ---
+
+
+def test_aa_alphabet_has_lut():
+    """Standard ACGT × k=3 alphabet builds the 64-entry LUT at __init__."""
+    assert sp.AA.codon_lut is not None
+    assert sp.AA.codon_lut.shape == (64,)
+    assert sp.AA.codon_lut.dtype == np.uint8
+
+
+def test_lut_translates_every_standard_codon():
+    """All 64 standard codons translate to the same AA via LUT as via the codon table."""
+    from seqpro._numba import gufunc_translate_lut
+
+    for codon, expected_aa in zip(sp.AA.codons, sp.AA.amino_acids, strict=True):
+        seq_kmer = sp.cast_seqs(codon).view(np.uint8)
+        actual = gufunc_translate_lut(seq_kmer, sp.AA.codon_lut)
+        assert int(actual) == ord(expected_aa), (
+            f"codon {codon!r} → {chr(int(actual))!r}, expected {expected_aa!r}"
+        )
+
+
+def test_lut_translates_stop_codons():
+    """The three stop codons TAA, TAG, TGA map to '*'."""
+    from seqpro._numba import gufunc_translate_lut
+
+    for stop in ("TAA", "TAG", "TGA"):
+        seq_kmer = sp.cast_seqs(stop).view(np.uint8)
+        actual = gufunc_translate_lut(seq_kmer, sp.AA.codon_lut)
+        assert chr(int(actual)) == "*", f"{stop} → {chr(int(actual))}, expected '*'"
+
+
+def test_lut_translates_start_codon():
+    """ATG → M."""
+    from seqpro._numba import gufunc_translate_lut
+
+    seq_kmer = sp.cast_seqs("ATG").view(np.uint8)
+    actual = gufunc_translate_lut(seq_kmer, sp.AA.codon_lut)
+    assert chr(int(actual)) == "M"
+
+
+def test_lut_and_linear_scan_produce_identical_output():
+    """Random-codon fuzz: LUT path == linear-scan path bitwise."""
+    from seqpro._numba import gufunc_translate_lut
+
+    rng = np.random.default_rng(0)
+    n = 5000
+    codons_idx = rng.choice(4, size=(n, 3))  # 0..3 per position
+    # Map index back to ASCII byte using the alphabet order (ACGT).
+    byte_for_idx = np.array([ord(c) for c in "ACGT"], dtype=np.uint8)
+    codons_bytes = byte_for_idx[codons_idx]  # (n, 3) uint8
+
+    kmer_keys = sp.AA.codon_array.view(np.uint8)
+    kmer_values = sp.AA.aa_array.view(np.uint8)
+    expected = gufunc_translate(codons_bytes, kmer_keys, kmer_values)
+    actual = gufunc_translate_lut(codons_bytes, sp.AA.codon_lut)
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_alphabet_translate_uses_lut_by_default():
+    """``sp.AA.translate`` should now go through the LUT path on standard
+    AA. Cross-validate against BioPython to confirm the LUT is correct."""
+    rng = np.random.default_rng(1)
+    nucs = list("ACGT")
+    seq = "".join(rng.choice(nucs, size=300, replace=True))
+    bio_aa = str(translate(seq))
+    sp_aa = sp.AA.translate(seq, length_axis=-1).view("S1")
+    np.testing.assert_array_equal(sp_aa, sp.cast_seqs(bio_aa))
+
+
 def case_1d():
     seqs = sp.cast_seqs("ATCGAT")
     desired = sp.cast_seqs("ID")

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -354,3 +354,96 @@ def test_translate_ragged_fallback_for_nonstandard_alphabet():
     rag = Ragged.from_lengths(data, np.array([6]))
     out = alpha.translate(rag)
     np.testing.assert_array_equal(_rag_bytes_to_array(out[0]), sp.cast_seqs("M*"))
+
+
+# --- path-activation tests ---
+# These guard that the LUT optimization is actually *used* for the standard
+# alphabet (and conversely that the scan is used for non-standard ones). Without
+# them, a regression that silently routed every call through the linear scan
+# would still pass every correctness test, because the scan is correct, just slow.
+
+
+def test_dense_standard_alphabet_uses_lut_not_scan(monkeypatch):
+    """Standard-alphabet dense path must hit the LUT kernel, never the scan."""
+    import seqpro.alphabets._alphabets as alpha_mod
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("linear scan was used instead of the LUT")
+
+    monkeypatch.setattr(alpha_mod, "gufunc_translate", _boom)
+    out = sp.AA.translate("ATGAAA", length_axis=-1).view("S1")
+    np.testing.assert_array_equal(out, sp.cast_seqs(str(translate("ATGAAA"))))
+
+
+def test_ragged_standard_alphabet_uses_lut_not_scan(monkeypatch):
+    """Standard-alphabet Ragged path must hit the LUT kernel, never the scan."""
+    import seqpro.alphabets._alphabets as alpha_mod
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("linear scan was used instead of the LUT")
+
+    monkeypatch.setattr(alpha_mod, "gufunc_translate", _boom)
+    rag = _make_ragged_bytes("ATGAAA")
+    out = sp.AA.translate(rag)
+    np.testing.assert_array_equal(_rag_bytes_to_array(out[0]), sp.cast_seqs("MK"))
+
+
+def test_nonstandard_alphabet_uses_scan_not_lut(monkeypatch):
+    """A non-standard (codon_lut=None) alphabet must use the scan, never the LUT."""
+    import seqpro.alphabets._alphabets as alpha_mod
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("LUT kernel was used for a non-standard alphabet")
+
+    monkeypatch.setattr(alpha_mod, "gufunc_translate_lut", _boom)
+    alpha = sp.AminoAlphabet(["AUG", "UAA"], ["M", "*"])
+    data = np.array(list("AUGUAA"), dtype="S1")
+    rag = Ragged.from_lengths(data, np.array([6]))
+    out = alpha.translate(rag)
+    np.testing.assert_array_equal(_rag_bytes_to_array(out[0]), sp.cast_seqs("M*"))
+
+
+# --- additional validate coverage ---
+
+
+def test_translate_ragged_bytes_validate_passes_on_valid():
+    """validate=True on clean multi-sequence Ragged bytes must not raise."""
+    rag = _make_ragged_bytes("ATGAAA", "GGGTTT")
+    out = sp.AA.translate(rag, validate=True)
+    np.testing.assert_array_equal(_rag_bytes_to_array(out[0]), sp.cast_seqs("MK"))
+    np.testing.assert_array_equal(_rag_bytes_to_array(out[1]), sp.cast_seqs("GF"))
+
+
+def test_translate_validate_passes_on_2d_valid():
+    """validate=True over a 2-D dense array of valid sequences must not raise."""
+    seqs = sp.cast_seqs(["ATGAAA", "GGGTTT"])
+    out = sp.AA.translate(seqs, length_axis=-1, validate=True)
+    np.testing.assert_array_equal(out, sp.cast_seqs(["MK", "GF"]))
+
+
+def test_translate_validate_raises_on_2d_with_invalid():
+    """A non-ACGT byte anywhere in a 2-D dense array is caught by validate=True."""
+    seqs = sp.cast_seqs(["ATGAAA", "ATGNNN"])  # second row has N
+    with pytest.raises(ValueError, match="outside the alphabet"):
+        sp.AA.translate(seqs, length_axis=-1, validate=True)
+
+
+def test_check_ohe_rows_raises_on_width_mismatch():
+    """OHE width not matching the nucleotide alphabet size raises a clear error."""
+    data = np.zeros((6, 5), dtype=np.uint8)  # width 5 != DNA's 4
+    with pytest.raises(ValueError, match="width"):
+        sp.AA._check_ohe_rows(data, 4)
+
+
+def test_translate_ragged_multiseq_matches_biopython():
+    """Differential check over a multi-sequence, variable-length Ragged batch."""
+    rng = np.random.default_rng(11)
+    seqs = [
+        "".join(rng.choice(list("ACGT"), size=3 * int(rng.integers(2, 40))))
+        for _ in range(5)
+    ]
+    rag = _make_ragged_bytes(*seqs)
+    out = sp.AA.translate(rag)
+    for i, s in enumerate(seqs):
+        expected = sp.cast_seqs(str(translate(s)))
+        np.testing.assert_array_equal(_rag_bytes_to_array(out[i]), expected)

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -247,3 +247,31 @@ def test_translate_ragged_error_bad_length():
     rag = _make_ragged_bytes("ATCG")  # length 4, not divisible by 3
     with pytest.raises(ValueError, match="divisible by codon"):
         sp.AA.translate(rag)
+
+
+def test_can_build_lut_predicate():
+    from seqpro.alphabets._alphabets import _can_build_lut
+
+    assert _can_build_lut(["ATG", "AAA"]) is True
+    assert _can_build_lut(["AUG"]) is False  # U is not in ACGT
+    assert _can_build_lut(["AT", "ATG"]) is False  # not all length-3
+    assert _can_build_lut(["AT"]) is False
+
+
+def test_nonstandard_alphabet_has_no_lut():
+    """A non-ACGT alphabet falls back: codon_lut is None."""
+    alpha = sp.AminoAlphabet(["AUG", "UAA"], ["M", "*"])
+    assert alpha.codon_lut is None
+
+
+def test_partial_acgt_alphabet_fills_unknown_with_X():
+    """A k=3 ACGT alphabet missing codons still builds a LUT; absent codons
+    resolve to the 'X' sentinel rather than garbage."""
+    from seqpro._numba import _pack_codon_index
+
+    alpha = sp.AminoAlphabet(["ATG"], ["M"])
+    assert alpha.codon_lut is not None
+    idx_atg = int(_pack_codon_index(ord("A"), ord("T"), ord("G")))
+    assert chr(alpha.codon_lut[idx_atg]) == "M"
+    idx_aaa = int(_pack_codon_index(ord("A"), ord("A"), ord("A")))
+    assert chr(alpha.codon_lut[idx_aaa]) == "X"

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -275,3 +275,33 @@ def test_partial_acgt_alphabet_fills_unknown_with_X():
     assert chr(alpha.codon_lut[idx_atg]) == "M"
     idx_aaa = int(_pack_codon_index(ord("A"), ord("A"), ord("A")))
     assert chr(alpha.codon_lut[idx_aaa]) == "X"
+
+
+# --- validate flag tests ---
+
+
+def test_translate_validate_passes_on_valid_acgt():
+    # Should not raise.
+    sp.AA.translate("ATGAAA", length_axis=-1, validate=True)
+
+
+def test_translate_validate_raises_on_lowercase():
+    with pytest.raises(ValueError, match="outside the alphabet"):
+        sp.AA.translate("atgAAA", length_axis=-1, validate=True)
+
+
+def test_translate_validate_raises_on_N():
+    with pytest.raises(ValueError, match="outside the alphabet"):
+        sp.AA.translate("ATGNNN", length_axis=-1, validate=True)
+
+
+def test_translate_validate_false_does_not_raise_on_invalid():
+    # Default path performs no validation and must not raise.
+    out = sp.AA.translate("ATGNNN", length_axis=-1, validate=False)
+    assert out.shape[-1] == 2
+
+
+def test_translate_ragged_bytes_validate_raises():
+    rag = _make_ragged_bytes("ATGNNN")
+    with pytest.raises(ValueError, match="outside the alphabet"):
+        sp.AA.translate(rag, validate=True)

--- a/tests/test_translate_lut_bench.py
+++ b/tests/test_translate_lut_bench.py
@@ -1,0 +1,61 @@
+"""Microbench: O(64) linear scan vs O(1) LUT in ``gufunc_translate``.
+
+Skipped under the default test selection; run explicitly with::
+
+    python tests/test_translate_lut_bench.py
+
+Expected speedup: 20-50× depending on CPU + cache effects. The LUT is
+64 bytes (fits in L1), the lookup is two shifts + two ors + one
+dereference per codon, while the original scan does up to 64 byte-array
+comparisons per codon.
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import seqpro as sp
+from seqpro._numba import gufunc_translate, gufunc_translate_lut
+
+
+def _bench(n_codons: int = 1_000_000, n_iters: int = 5) -> tuple[float, float, int]:
+    """Time both paths over ``n_iters`` iterations.
+
+    Returns
+    -------
+    (t_linear, t_lut, n_diff)
+    """
+    rng = np.random.default_rng(42)
+    byte_for_idx = np.array([ord(c) for c in "ACGT"], dtype=np.uint8)
+    codons = byte_for_idx[rng.choice(4, size=(n_codons, 3))]  # (n, 3) uint8
+    kmer_keys = sp.AA.codon_array.view(np.uint8)
+    kmer_values = sp.AA.aa_array.view(np.uint8)
+
+    # Warm up (Numba caches compiled signatures across calls)
+    _ = gufunc_translate(codons[:100], kmer_keys, kmer_values)
+    _ = gufunc_translate_lut(codons[:100], sp.AA.codon_lut)
+
+    times_linear, times_lut = [], []
+    for _ in range(n_iters):
+        t0 = time.perf_counter()
+        old = gufunc_translate(codons, kmer_keys, kmer_values)
+        times_linear.append(time.perf_counter() - t0)
+
+        t0 = time.perf_counter()
+        new = gufunc_translate_lut(codons, sp.AA.codon_lut)
+        times_lut.append(time.perf_counter() - t0)
+
+    n_diff = int((old != new).sum())
+    return min(times_linear), min(times_lut), n_diff
+
+
+if __name__ == "__main__":
+    n = 1_000_000
+    t_old, t_new, n_diff = _bench(n)
+    print(f"Benchmark: {n:,} codons (min over 5 iters)")
+    print(f"  linear scan: {t_old * 1000:8.1f} ms  ({n / t_old / 1e6:.1f} M codons/s)")
+    print(f"  LUT lookup:  {t_new * 1000:8.1f} ms  ({n / t_new / 1e6:.1f} M codons/s)")
+    print(f"  speedup:     {t_old / t_new:.1f}x")
+    print(f"  outputs differ in {n_diff} of {n} positions (0 = correct)")
+    assert n_diff == 0


### PR DESCRIPTION
## Summary

Adds and hardens an O(1) lookup-table (LUT) path for `AminoAlphabet.translate`, and introduces an opt-in `validate` flag that guarantees in-alphabet input.

For the standard genetic code (k=3, ACGT), translation is done via a 64-entry codon→amino-acid LUT indexed by a 2-bit-per-nucleotide hash (`(byte >> 1) & 3`), replacing the previous O(64) linear scan over the codon table. The slow path remains as a fallback for non-standard alphabets (different codon size or extended/IUPAC characters). Output is identical to the linear scan for valid ACGT input.

## What's included

- **O(1) LUT path on both the dense and Ragged paths.** The original change wired the LUT into the dense/non-Ragged path only; the variable-length (Ragged) path — the genome-scale workload that motivated this — now uses it too, with the same `codon_lut is not None` branch and scan fallback.
- **Opt-in `validate` flag** (`AminoAlphabet.translate(..., validate=False)`). When `validate=True`, translation raises `ValueError` on any input outside the alphabet:
  - **String/byte input:** any non-ACGT byte (lowercase, `N`, IUPAC ambiguity codes).
  - **OHE input:** any row that is not exactly one-hot (a structural check — necessary because a multi-hot row would otherwise silently decode to a real nucleotide).
  - When `validate=True` returns without raising, the translation is guaranteed exact. The default `validate=False` preserves the zero-overhead fast path and treats out-of-alphabet input as undefined.
- **Single source of truth for the index hash.** The codon→index bit-pack lives in one `@nb.njit` helper (`_pack_codon_index`) used by both the runtime kernel and the table builder, so they cannot drift.
- **Predicate-gated LUT construction.** `_can_build_lut` replaces control-flow-by-exception; the `'X'` sentinel now serves as a genuine safety net for partial ACGT/k=3 alphabets.
- **Docstrings carry no hardware-specific speed claims** (speedups are data- and hardware-dependent). The microbenchmark is retained as `tests/bench_translate_lut.py` (renamed out of pytest collection) and reports measured numbers when run.
- **Docs:** `skills/seqpro/SKILL.md` documents the `validate` flag. Design spec and implementation plan are committed under `docs/superpowers/`.

## Versioning

This now adds a new public capability (`validate`), so it is a **`feat:`** → **minor** bump rather than a pure `perf:`/patch.

## Test Plan

- [x] Full suite green: `pytest tests/` → 275 passed, 1 skipped, 2 xfailed, 2 xpassed.
- [x] LUT output is bitwise-identical to the linear scan for valid ACGT (existing fuzz + new equality tests).
- [x] BioPython cross-validation on dense and Ragged paths.
- [x] `validate=True` raises on lowercase / `N` / non-ACGT (dense + Ragged) and on multi-hot / all-zero / 1-D OHE input; passes on valid input; `validate=False` never raises.
- [x] Non-standard alphabet → `codon_lut is None` → scan fallback, correct output.
- [x] `ruff check` and `ruff format --check` clean; benchmark excluded from collection.