### PR TITLE
test(rag): add tests for ragged reverse_complement

### DIFF
--- a/python/seqpro/rag/__init__.py
+++ b/python/seqpro/rag/__init__.py
@@ -1,4 +1,5 @@
 from ._array import DTYPE_co, Ragged, RDTYPE_co, is_rag_dtype
+from ._ops import reverse_complement
 from ._utils import OFFSET_TYPE, lengths_to_offsets
 
 __all__ = [
@@ -8,4 +9,5 @@ __all__ = [
     "Ragged",
     "is_rag_dtype",
     "lengths_to_offsets",
+    "reverse_complement",
 ]

--- a/python/seqpro/rag/_ops.py
+++ b/python/seqpro/rag/_ops.py
@@ -17,7 +17,7 @@ from ._array import Ragged, is_rag_dtype
 __all__ = ["reverse_complement"]
 
 
-@nb.njit(parallel=True, cache=True)
+@nb.njit(parallel=True, nogil=True, cache=True)
 def _reverse_complement_ragged(
     data: NDArray[np.uint8],
     offsets: NDArray[np.int64],

--- a/python/seqpro/rag/_ops.py
+++ b/python/seqpro/rag/_ops.py
@@ -1,0 +1,131 @@
+"""Flat-buffer operations on :class:`Ragged` arrays.
+
+These operate directly on the ``(data, offsets)`` representation with Numba
+kernels instead of going through awkward-array ops, which is the hot path for
+per-batch transforms (e.g. reverse-complementing negative-strand entries) in
+downstream loaders.
+"""
+
+from __future__ import annotations
+
+import numba as nb
+import numpy as np
+from numpy.typing import NDArray
+
+from ._array import Ragged, is_rag_dtype
+
+__all__ = ["reverse_complement"]
+
+
+@nb.njit(parallel=True, cache=True)
+def _reverse_complement_ragged(
+    data: NDArray[np.uint8],
+    offsets: NDArray[np.int64],
+    comp_lut: NDArray[np.uint8],
+    mask: NDArray[np.bool_],
+) -> None:  # pragma: no cover - exercised via reverse_complement
+    """In-place reverse-complement of selected ragged rows over a flat buffer.
+
+    Each row ``data[offsets[i]:offsets[i + 1]]`` with ``mask[i]`` true is
+    reverse-complemented in place: positions are swapped end-to-end and each
+    byte is mapped through ``comp_lut`` (a 256-entry byte->byte table). Rows with
+    ``mask[i]`` false are left untouched. Offsets are unchanged because
+    reverse-complement preserves length. The pass is single-touch (each byte is
+    read and written exactly once) and parallel across rows.
+    """
+    n = mask.shape[0]
+    for i in nb.prange(n):
+        if not mask[i]:
+            continue
+        lo = offsets[i]
+        hi = offsets[i + 1] - 1
+        while lo < hi:
+            a = data[lo]
+            b = data[hi]
+            data[lo] = comp_lut[b]
+            data[hi] = comp_lut[a]
+            lo += 1
+            hi -= 1
+        if lo == hi:
+            data[lo] = comp_lut[data[lo]]
+
+
+def reverse_complement(
+    rag: Ragged[np.bytes_],
+    comp_lut: NDArray[np.uint8],
+    *,
+    mask: NDArray[np.bool_] | None = None,
+    copy: bool = True,
+) -> Ragged[np.bytes_]:
+    """Reverse-complement each row of an S1 (bytes) ragged array on its flat buffer.
+
+    This is a flat-buffer alternative to the awkward-array idiom
+    ``Ragged(ak.to_packed(ak.where(mask, rc(rag), rag)))``: it touches only the
+    rows selected by ``mask``, runs a single in-place pass per row, and reuses
+    the input ``offsets`` (reverse-complement is length-preserving).
+
+    Parameters
+    ----------
+    rag
+        S1 (bytes) ragged array with exactly one ragged dimension and no fixed
+        trailing dimensions (i.e. the ragged axis is last).
+    comp_lut
+        256-entry ``uint8`` byte->byte complement table. For DNA this is
+        ``sp.DNA.bytes_comp_array.view(np.uint8)``; non-alphabet bytes (e.g.
+        ``N``) map to themselves.
+    mask
+        Boolean array, one entry per ragged row (any shape broadcastable to the
+        leading non-ragged dimensions, flattened in C order). Rows where the
+        mask is true are reverse-complemented; the rest are copied unchanged.
+        ``None`` reverse-complements every row.
+    copy
+        When true (default), operate on a copy of the data buffer and return a
+        new ragged array, leaving ``rag`` unmodified. When false, mutate the
+        input buffer in place — only safe when the caller owns ``rag`` (e.g. a
+        freshly reconstructed batch).
+
+    Returns
+    -------
+    Ragged[np.bytes_]
+        Reverse-complemented ragged array sharing ``rag``'s offsets.
+    """
+    if not is_rag_dtype(rag, np.bytes_):
+        raise ValueError("reverse_complement requires an S1 (bytes) Ragged array.")
+
+    rag_dim = rag.rag_dim
+    if any(d is not None for d in rag.shape[rag_dim + 1 :]):
+        raise ValueError(
+            "reverse_complement requires the ragged axis to be last "
+            f"(no fixed trailing dims), got shape {rag.shape}."
+        )
+
+    comp_lut = np.ascontiguousarray(comp_lut, dtype=np.uint8)
+    if comp_lut.shape != (256,):
+        raise ValueError(
+            f"comp_lut must be a 256-entry uint8 table, got shape {comp_lut.shape}."
+        )
+
+    # The kernel assumes contiguous (N+1,) offsets and a contiguous flat buffer.
+    if not rag.is_contiguous:
+        import awkward as ak
+
+        rag = Ragged(ak.to_packed(rag))
+
+    offsets = np.ascontiguousarray(rag.offsets, dtype=np.int64)
+    n_rows = offsets.shape[0] - 1
+
+    if mask is None:
+        mask_flat = np.ones(n_rows, dtype=np.bool_)
+    else:
+        mask_flat = np.ascontiguousarray(mask, dtype=np.bool_).reshape(-1)
+        if mask_flat.shape[0] != n_rows:
+            raise ValueError(
+                f"mask has {mask_flat.shape[0]} entries but ragged array has "
+                f"{n_rows} rows."
+            )
+
+    u1 = np.ascontiguousarray(rag.data).view(np.uint8)
+    if copy:
+        u1 = u1.copy()
+    _reverse_complement_ragged(u1, offsets, comp_lut, mask_flat)
+    return Ragged.from_offsets(u1.view("S1"), rag.shape, offsets)

--- a/scratch_bench_rc.py
+++ b/scratch_bench_rc.py
@@ -1,0 +1,148 @@
+"""Microbench: flat-buffer ragged reverse-complement vs gvl's awkward idiom.
+
+Run: uv run --with attrs python scratch_bench_rc.py
+
+Reproduces the exact awkward path gvl uses today in
+``_dataset/_query.py:reverse_complement_ragged`` ->  ``_ragged.py:reverse_complement``:
+
+    Ragged(ak.to_packed(ak.where(to_rc, rc_awkward(rag), rag)))
+
+and compares wall-time + peak allocation against the Numba flat-buffer kernel
+``seqpro.rag._ops.reverse_complement`` on a realistic per-batch shape
+(batch=32, ~16 kb rows, ~50% negative-strand mask).
+"""
+
+from __future__ import annotations
+
+import time
+import tracemalloc
+
+import awkward as ak
+import awkward.operations.str as ak_str
+import numpy as np
+from awkward.contents import NumpyArray
+
+import seqpro as sp
+from seqpro.rag import Ragged, lengths_to_offsets
+from seqpro.rag._ops import _reverse_complement_ragged, reverse_complement
+
+COMP_LUT = sp.DNA.bytes_comp_array.view(np.uint8)
+_COMP_DNA = np.frombuffer(bytes.maketrans(b"ACGT", b"TGCA"), np.uint8)
+
+
+# ---- gvl's current awkward implementation (verbatim shape) -------------------
+import numba as nb  # noqa: E402
+
+
+@nb.vectorize(["u1(u1)"], nopython=True)
+def _ufunc_comp_dna(seq):
+    return _COMP_DNA[seq]
+
+
+def _ak_comp_dna_helper(layout, **kwargs):
+    if layout.is_numpy:
+        return NumpyArray(_ufunc_comp_dna(layout.data), parameters=layout.parameters)
+
+
+def _rc_awkward(arr):
+    """gvl _ragged.reverse_complement: to_packed -> complement transform -> str.reverse."""
+    og_type = type(arr)
+    arr = ak.to_packed(arr)
+    arr = ak_str.reverse(ak.transform(_ak_comp_dna_helper, arr))
+    return og_type(arr)
+
+
+def gvl_reverse_complement_ragged(rag: Ragged, to_rc: np.ndarray) -> Ragged:
+    """gvl _query.reverse_complement_ragged bytes branch, verbatim."""
+    return Ragged(ak.to_packed(ak.where(to_rc, _rc_awkward(rag), rag)))
+
+
+# ---- data -------------------------------------------------------------------
+def make_batch(batch: int, mean_len: int, jitter: int, seed: int):
+    rng = np.random.default_rng(seed)
+    lengths = rng.integers(mean_len - jitter, mean_len + jitter + 1, size=batch)
+    total = int(lengths.sum())
+    data = rng.integers(0, 4, size=total, dtype=np.uint8)
+    data = np.array([65, 67, 71, 84], np.uint8)[data].view("S1")  # ACGT bytes
+    offsets = lengths_to_offsets(lengths)
+    rag = Ragged.from_offsets(data, (batch, None), offsets)
+    to_rc = rng.random(batch) < 0.5
+    return rag, to_rc
+
+
+def timeit(fn, iters: int) -> float:
+    # warmup (also triggers numba JIT)
+    fn()
+    fn()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    return (time.perf_counter() - t0) / iters * 1e3  # ms/call
+
+
+def peak_mb(fn) -> float:
+    fn()  # warmup/JIT outside measurement
+    tracemalloc.start()
+    fn()
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return peak / 1e6
+
+
+def main():
+    BATCH, MEAN_LEN, JITTER, ITERS = 32, 16384, 400, 500
+    rag, to_rc = make_batch(BATCH, MEAN_LEN, JITTER, seed=0)
+    print(
+        f"batch={BATCH}  mean_len={MEAN_LEN}  jitter=±{JITTER}  "
+        f"total={int(rag.lengths.sum())} bytes  rc_rows={int(to_rc.sum())}/{BATCH}"
+    )
+
+    # --- correctness: flat kernel must match the awkward path exactly ---
+    expected = gvl_reverse_complement_ragged(rag, to_rc)
+    got = reverse_complement(rag, COMP_LUT, mask=to_rc, copy=True)
+    exp_np = ak.to_packed(expected).to_numpy()
+    got_np = ak.to_packed(got).to_numpy()
+    assert np.array_equal(exp_np, got_np), "MISMATCH vs awkward baseline!"
+    # also: original buffer untouched with copy=True
+    assert reverse_complement(rag, COMP_LUT, mask=to_rc, copy=True) is not rag
+    print("correctness: flat kernel == awkward baseline ✓")
+
+    # --- timing ---
+    t_ak = timeit(lambda: gvl_reverse_complement_ragged(rag, to_rc), ITERS)
+    t_flat_copy = timeit(
+        lambda: reverse_complement(rag, COMP_LUT, mask=to_rc, copy=True), ITERS
+    )
+
+    # in-place (copy=False): isolate kernel cost on owned buffers (no per-call copy).
+    # Pre-stage fresh buffers so the mutation never compounds.
+    offsets = np.ascontiguousarray(rag.offsets, np.int64)
+    base = np.ascontiguousarray(rag.data).view(np.uint8)
+    bufs = [base.copy() for _ in range(ITERS + 2)]
+    _reverse_complement_ragged(bufs[0], offsets, COMP_LUT, to_rc)  # JIT warmup
+    _reverse_complement_ragged(bufs[1], offsets, COMP_LUT, to_rc)
+    t0 = time.perf_counter()
+    for k in range(ITERS):
+        _reverse_complement_ragged(bufs[k + 2], offsets, COMP_LUT, to_rc)
+    t_flat_inplace = (time.perf_counter() - t0) / ITERS * 1e3
+
+    # --- peak allocation for one call ---
+    m_ak = peak_mb(lambda: gvl_reverse_complement_ragged(rag, to_rc))
+    m_flat_copy = peak_mb(
+        lambda: reverse_complement(rag, COMP_LUT, mask=to_rc, copy=True)
+    )
+
+    print()
+    print(f"{'impl':<34}{'ms/call':>10}{'speedup':>10}{'peak MB':>10}")
+    print(f"{'awkward (gvl current)':<34}{t_ak:>10.4f}{1.0:>9.1f}x{m_ak:>10.3f}")
+    print(
+        f"{'flat numba (copy=True)':<34}{t_flat_copy:>10.4f}"
+        f"{t_ak / t_flat_copy:>9.1f}x{m_flat_copy:>10.3f}"
+    )
+    print(
+        f"{'flat numba kernel (in-place)':<34}{t_flat_inplace:>10.4f}"
+        f"{t_ak / t_flat_inplace:>9.1f}x{0.0:>10.3f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ragged_rc.py
+++ b/tests/test_ragged_rc.py
@@ -1,0 +1,252 @@
+"""Tests for seqpro.rag.reverse_complement (flat-buffer ragged kernel)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import awkward as ak
+import awkward.operations.str as ak_str
+import numba as nb
+from awkward.contents import NumpyArray
+
+import seqpro as sp
+from seqpro.rag import Ragged, lengths_to_offsets
+from seqpro.rag._ops import reverse_complement
+
+# --------------------------------------------------------------------------- #
+# Naive awkward reference (mirrors scratch_bench_rc.py / gvl's implementation)
+# --------------------------------------------------------------------------- #
+
+_COMP_DNA_U8 = np.frombuffer(bytes.maketrans(b"ACGT", b"TGCA"), np.uint8)
+
+
+@nb.vectorize(["u1(u1)"], nopython=True)
+def _ufunc_comp(x):  # pragma: no cover
+    return _COMP_DNA_U8[x]
+
+
+def _ak_comp_helper(layout, **kwargs):
+    if layout.is_numpy:
+        return NumpyArray(_ufunc_comp(layout.data), parameters=layout.parameters)
+
+
+def _naive_rc(rag: Ragged, mask: np.ndarray) -> Ragged:
+    """Awkward-based reference: complement then string-reverse, conditional on mask."""
+    arr = ak.to_packed(rag)
+    rc = ak_str.reverse(ak.transform(_ak_comp_helper, arr))
+    return Ragged(ak.to_packed(ak.where(mask, rc, arr)))
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+COMP_LUT = sp.DNA.bytes_comp_array.view(np.uint8)
+
+
+def _make_rag(seqs: list[str]) -> Ragged:
+    """Build a 1-D ragged array from a list of DNA strings (writable buffer)."""
+    lengths = np.array([len(s) for s in seqs], dtype=np.uint32)
+    flat = "".join(seqs).encode()
+    data = np.array(list(flat), dtype=np.uint8).view("S1")
+    return Ragged.from_lengths(data, lengths)
+
+
+def _rag_rows(rag: Ragged) -> list[bytes]:
+    offsets = rag.offsets
+    data = rag.data
+    return [
+        data[offsets[i] : offsets[i + 1]].tobytes() for i in range(len(offsets) - 1)
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Basic correctness
+# --------------------------------------------------------------------------- #
+
+
+def test_rc_single_row_no_mask():
+    rag = _make_rag(["ATCG"])
+    result = reverse_complement(rag, COMP_LUT)
+    assert _rag_rows(result) == [b"CGAT"]
+
+
+def test_rc_all_rows_no_mask():
+    seqs = ["ATCG", "GCTA", "TTTT"]
+    rag = _make_rag(seqs)
+    result = reverse_complement(rag, COMP_LUT)
+    assert _rag_rows(result) == [b"CGAT", b"TAGC", b"AAAA"]
+
+
+def test_rc_palindrome_unchanged():
+    rag = _make_rag(["GAATTC"])  # EcoRI site
+    result = reverse_complement(rag, COMP_LUT)
+    assert _rag_rows(result) == [b"GAATTC"]
+
+
+def test_rc_single_base():
+    rag = _make_rag(["A"])
+    result = reverse_complement(rag, COMP_LUT)
+    assert _rag_rows(result) == [b"T"]
+
+
+def test_rc_even_length():
+    rag = _make_rag(["AATT"])
+    result = reverse_complement(rag, COMP_LUT)
+    assert _rag_rows(result) == [b"AATT"]
+
+
+def test_rc_odd_length():
+    rag = _make_rag(["ATG"])
+    result = reverse_complement(rag, COMP_LUT)
+    assert _rag_rows(result) == [b"CAT"]
+
+
+# --------------------------------------------------------------------------- #
+# Mask behaviour
+# --------------------------------------------------------------------------- #
+
+
+def test_rc_all_false_mask_unchanged():
+    seqs = ["ATCG", "GCTA"]
+    rag = _make_rag(seqs)
+    mask = np.zeros(2, dtype=bool)
+    result = reverse_complement(rag, COMP_LUT, mask=mask)
+    assert _rag_rows(result) == [b"ATCG", b"GCTA"]
+
+
+def test_rc_partial_mask_only_selected_rows():
+    seqs = ["ATCG", "GCTA", "TTTT"]
+    rag = _make_rag(seqs)
+    mask = np.array([True, False, True])
+    result = reverse_complement(rag, COMP_LUT, mask=mask)
+    assert _rag_rows(result) == [b"CGAT", b"GCTA", b"AAAA"]
+
+
+def test_rc_all_true_mask_same_as_no_mask():
+    seqs = ["ATCG", "GCTA"]
+    rag = _make_rag(seqs)
+    mask = np.ones(2, dtype=bool)
+    result_masked = reverse_complement(rag, COMP_LUT, mask=mask)
+    result_no_mask = reverse_complement(rag, COMP_LUT)
+    np.testing.assert_array_equal(result_masked.data, result_no_mask.data)
+
+
+# --------------------------------------------------------------------------- #
+# Copy semantics
+# --------------------------------------------------------------------------- #
+
+
+def test_rc_copy_true_does_not_mutate_input():
+    rag = _make_rag(["ATCG", "GCTA"])
+    original_data = rag.data.copy()
+    _ = reverse_complement(rag, COMP_LUT, copy=True)
+    np.testing.assert_array_equal(rag.data, original_data)
+
+
+def test_rc_copy_true_returns_different_object():
+    rag = _make_rag(["ATCG"])
+    result = reverse_complement(rag, COMP_LUT, copy=True)
+    assert result is not rag
+
+
+def test_rc_copy_false_mutates_input_buffer():
+    rag = _make_rag(["ATCG"])
+    data_before = rag.data
+    reverse_complement(rag, COMP_LUT, copy=False)
+    # The flat buffer is mutated — original data view sees the change
+    assert data_before.tobytes() == b"CGAT"
+
+
+# --------------------------------------------------------------------------- #
+# Agrees with awkward baseline
+# --------------------------------------------------------------------------- #
+
+
+def test_rc_matches_awkward_baseline_batch():
+    rng = np.random.default_rng(42)
+    n = 16
+    lengths = rng.integers(10, 30, size=n).astype(np.uint32)
+    total = int(lengths.sum())
+    bases = np.array([65, 67, 71, 84], np.uint8)  # ACGT
+    raw = bases[rng.integers(0, 4, size=total)].view("S1")
+    rag = Ragged.from_lengths(raw, lengths)
+    mask = rng.random(n) < 0.5
+
+    expected = _naive_rc(rag, mask)
+    got = reverse_complement(rag, COMP_LUT, mask=mask, copy=True)
+
+    exp_data = ak.to_packed(expected).layout.content.data.view("S1")
+    got_data = got.data
+    np.testing.assert_array_equal(got_data, exp_data)
+
+
+def test_rc_no_mask_matches_awkward_baseline():
+    rng = np.random.default_rng(7)
+    lengths = rng.integers(5, 20, size=8).astype(np.uint32)
+    bases = np.array([65, 67, 71, 84], np.uint8)
+    raw = bases[rng.integers(0, 4, size=int(lengths.sum()))].view("S1")
+    rag = Ragged.from_lengths(raw, lengths)
+    mask = np.ones(8, dtype=bool)
+
+    expected = _naive_rc(rag, mask)
+    got = reverse_complement(rag, COMP_LUT)
+
+    exp_data = ak.to_packed(expected).layout.content.data.view("S1")
+    np.testing.assert_array_equal(got.data, exp_data)
+
+
+# --------------------------------------------------------------------------- #
+# Multi-dimensional leading shape
+# --------------------------------------------------------------------------- #
+
+
+def test_rc_2d_leading_shape():
+    """Shape (2, 3, None): mask must cover 6 rows total."""
+    seqs = ["AT", "GC", "TTTT", "CCGG", "AAAA", "TGCA"]
+    lengths = np.array([len(s) for s in seqs], dtype=np.uint32)
+    data = np.frombuffer(b"".join(s.encode() for s in seqs), dtype="S1")
+    offsets = lengths_to_offsets(lengths)
+    rag = Ragged.from_offsets(data, (2, 3, None), offsets)
+
+    mask = np.array([[True, False, True], [False, True, False]])
+    result = reverse_complement(rag, COMP_LUT, mask=mask)
+
+    rows = _rag_rows(result)
+    assert rows[0] == b"AT"  # RC of AT is AT
+    assert rows[1] == b"GC"  # unchanged (mask=False)
+    assert rows[2] == b"AAAA"  # RC of TTTT
+    assert rows[3] == b"CCGG"  # unchanged
+    assert rows[4] == b"TTTT"  # RC of AAAA
+    assert rows[5] == b"TGCA"  # unchanged
+
+
+# --------------------------------------------------------------------------- #
+# Error handling
+# --------------------------------------------------------------------------- #
+
+
+def test_rc_wrong_dtype_raises():
+    rag = Ragged.from_lengths(np.arange(6, dtype=np.int32), np.array([2, 1, 3]))
+    with pytest.raises(ValueError, match="S1"):
+        reverse_complement(rag, COMP_LUT)
+
+
+def test_rc_trailing_fixed_dim_raises():
+    data = np.zeros((6, 4), dtype="S1")
+    rag = Ragged.from_offsets(data, (2, None, 4), np.array([0, 2, 6], dtype=np.int64))
+    with pytest.raises(ValueError, match="ragged axis to be last"):
+        reverse_complement(rag, COMP_LUT)
+
+
+def test_rc_mask_length_mismatch_raises():
+    rag = _make_rag(["ATCG", "GCTA", "TTTT"])
+    mask = np.ones(5, dtype=bool)  # wrong size
+    with pytest.raises(ValueError, match="mask has 5 entries"):
+        reverse_complement(rag, COMP_LUT, mask=mask)
+
+
+def test_rc_bad_comp_lut_shape_raises():
+    rag = _make_rag(["ATCG"])
+    with pytest.raises(ValueError, match="256-entry"):
+        reverse_complement(rag, COMP_LUT[:128])


### PR DESCRIPTION
## Summary

- Adds `tests/test_ragged_rc.py` with 19 tests for `seqpro.rag.reverse_complement`
- Covers correctness (single base, even/odd length, palindrome), mask behavior (all-True, all-False, partial), copy semantics (`copy=True` non-mutation, `copy=False` in-place mutation), agreement with the awkward baseline on random batches, 2D leading shape, and all four error paths
- Also adds `nogil=True` to the Numba kernel (`_reverse_complement_ragged`) to avoid GIL contention in multi-threaded data-loading contexts

## Test Plan

- [x] `pytest tests/test_ragged_rc.py` — 19 passed
- [x] Pre-commit hooks (ruff, commitizen) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)