### PR TITLE
fix(ci): check out release tag and drop duplicate release trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,6 @@
 name: Create release
 
 on:
-  push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       tag:
@@ -30,15 +27,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag }}
 
       - name: Resolve tag
         id: tag
-        run: |
-          case "${{ github.event_name }}" in
-            push)          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT ;;
-            workflow_dispatch) echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT ;;
-            workflow_call) echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT ;;
-          esac
+        run: echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
 
       - name: Extract changelog section
         run: |


### PR DESCRIPTION
## Problem

The `0.13.0` GitHub release was published with an **empty body** — the changelog section never made it in.

Root cause: `release.yaml` ran **twice** per release and the broken run won the race.

- It triggered on both `push: tags` *and* `workflow_call` (from `release-pipeline.yaml`), so two jobs raced to create the same release.
- The `workflow_call` job's `actions/checkout` had no `ref:`, so it defaulted to the caller's triggering SHA — the **pre-bump** commit (`54ff037`), which still topped out at `## 0.12.1`. The awk extraction found no `## 0.13.0` section → empty `body.md`.
- That run published at `01:48:13`, beating the correctly-checked-out tag-push run, leaving the release body `null`.

## Fix

- **Drop the `push: tags` trigger** — the pipeline already calls `release` via `workflow_call`, so the second trigger was pure duplication/race.
- **Pin `checkout` to `ref: ${{ inputs.tag }}`** so the tag commit (which contains the changelog) is always checked out, regardless of trigger.
- Simplify the now-redundant "Resolve tag" step (the dead `push` case is removed).

The already-published `0.13.0` release body has been backfilled manually via `gh release edit`.

## Notes

CI-only change; no public API or signature changes, so no `skills/seqpro/SKILL.md` update required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)