### PR TITLE
test: cover unpacked 1-D ListOffsetArray in to_packed

### DIFF
--- a/tests/test_rag_to_packed.py
+++ b/tests/test_rag_to_packed.py
@@ -29,6 +29,23 @@ class TestToPackedFlat:
         # matches awkward's packing exactly
         assert ak.to_list(out) == ak.to_list(ak.to_packed(rag))
 
+    def test_1d_offsets_unpacked_rebases(self):
+        # A contiguous slice keeps a 1-D ListOffsetArray but with a non-zero
+        # base (offsets[0] != 0) and untrimmed content -> exercises the
+        # offsets.ndim == 1 gather path (starts = offsets[:-1]) in _pack_parts.
+        full = Ragged.from_lengths(np.arange(9, dtype=np.float64), np.array([3, 2, 4]))
+        rag = full[1:]
+        assert rag.offsets.ndim == 1
+        assert rag.offsets[0] != 0  # not zero-based -> unpacked
+        out = to_packed(rag)
+        assert out.offsets.ndim == 1
+        assert out.offsets[0] == 0
+        assert out.is_contiguous
+        assert out.data.shape[0] == 6  # content trimmed to packed extent
+        assert not np.shares_memory(out.data, rag.data)  # rebased into fresh buffer
+        assert ak.to_list(out) == ak.to_list(rag)
+        assert ak.to_list(out) == ak.to_list(ak.to_packed(rag))
+
     def test_bytes_dtype(self):
         seqs = ["ATG", "C", "GGGG"]
         data = np.frombuffer("".join(seqs).encode("ascii"), dtype="S1").copy()


### PR DESCRIPTION
## Summary

Closes a coverage gap in `to_packed`: the `offsets.ndim == 1` gather path in `_pack_parts` (`python/seqpro/rag/_ops.py:174`) was only ever reached through the 2-D `ListArray` branch. Every 1-D `ListOffsetArray` in the existing suite came from a fresh `Ragged.from_lengths(...)`, which is already packed and so only hit the fast paths (`data.copy()` and the `copy=False` passthrough).

The new test constructs a contiguous slice `full[1:]`, which keeps a 1-D `ListOffsetArray` but with a non-zero base (`offsets[0] != 0`) and untrimmed content — i.e. unpacked while staying `ndim == 1`. This drives the real `_pack` kernel via the 1-D branch and asserts:

- the rebase (`[3 5 9]` → `[0 2 6]`)
- content trimming (9 → 6 elements)
- a freshly allocated buffer (no shared memory)
- value-equality with both the input and `ak.to_packed`

Coverage is now symmetric across both awkward layouts: `ListArray` (2-D, via the existing `_unpacked()` reversal tests) and `ListOffsetArray` (1-D, in both packed and unpacked forms).

Test-only change — no public API or behavior change.

## Test plan

- [x] `pytest tests/test_rag_to_packed.py` — 14 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)