### PR TITLE
fix(rag): traverse IndexedArray in unbox/_extract_list_offsets

### DIFF
--- a/python/seqpro/rag/_array.py
+++ b/python/seqpro/rag/_array.py
@@ -9,6 +9,8 @@ from attrs import define
 from awkward.contents import (
     Content,
     EmptyArray,
+    IndexedArray,
+    IndexedOptionArray,
     ListArray,
     ListOffsetArray,
     NumpyArray,
@@ -82,6 +84,13 @@ def _is_record_layout(layout: Content) -> bool:
     return has_list and isinstance(node, RecordArray)
 
 
+def _is_indexed_record(layout: Content) -> bool:
+    """Return True if layout is an IndexedArray/IndexedOptionArray whose projected content is a RecordArray."""
+    return isinstance(layout, (IndexedArray, IndexedOptionArray)) and isinstance(
+        layout.project(), RecordArray
+    )
+
+
 def _extract_list_offsets(layout: Content) -> NDArray[OFFSET_TYPE]:
     """Extract offsets from the (single) list layer in a record-layout Ragged.
 
@@ -96,11 +105,15 @@ def _extract_list_offsets(layout: Content) -> NDArray[OFFSET_TYPE]:
     """
     node = layout
     while True:
-        if isinstance(node, ListOffsetArray):
+        if isinstance(node, (IndexedArray, IndexedOptionArray)):
+            # Ragged carries no missing values; project() collapses the index.
+            # (An option array with real None would drop rows and desync shape[0].)
+            node = node.project()
+        elif isinstance(node, ListOffsetArray):
             return np.asarray(node.offsets.data)
-        if isinstance(node, ListArray):
+        elif isinstance(node, ListArray):
             return np.stack([node.starts.data, node.stops.data], 0)  # type: ignore
-        if isinstance(node, RegularArray):
+        elif isinstance(node, RegularArray):
             node = node.content
         elif isinstance(node, RecordArray):
             node = node.content(0)
@@ -174,7 +187,11 @@ class Ragged(ak.Array, Generic[RDTYPE_co]):
         else:
             content = _as_ragged(data, highlevel=False)
         super().__init__(content, behavior=deepcopy(ak.behavior))
-        if isinstance(content, RecordArray) or _is_record_layout(content):
+        if (
+            isinstance(content, RecordArray)
+            or _is_record_layout(content)
+            or _is_indexed_record(content)
+        ):
             # ak._update_class() demotes RecordArray layouts to plain ak.Array
             # because there is no "__list__" parameter at the record level.
             # Restore the Ragged subclass and cache per-field RagParts.
@@ -196,7 +213,11 @@ class Ragged(ak.Array, Generic[RDTYPE_co]):
         if hasattr(self, "_parts"):
             return
         layout = cast(Content, ak.to_layout(self))
-        if isinstance(layout, RecordArray) or _is_record_layout(layout):
+        if (
+            isinstance(layout, RecordArray)
+            or _is_record_layout(layout)
+            or _is_indexed_record(layout)
+        ):
             # Set sentinel first to break the self[f] -> _ensure_parts cycle.
             object.__setattr__(self, "_parts", {})
             shared_offsets = _extract_list_offsets(layout)
@@ -758,7 +779,11 @@ class RagParts(Generic[DTYPE_co]):
 
 def unbox(arr: ak.Array | Ragged[DTYPE_co]) -> RagParts[DTYPE_co]:
     """Unbox an awkward array with a single ragged dimension into data, offsets, and shape.
-    Always zero-copy: the returned data is a view of the original array.
+    Always a view: the returned data references the original flat buffer. Indexed
+    layouts (e.g. from fancy-indexing a record then extracting a field) are collapsed
+    via ``project()``, which only reorders the list pointers into ``starts``/``stops``
+    (the flat data is still shared), so callers needing contiguous, row-ordered data
+    must pack afterwards (e.g. ``to_packed``).
 
     Parameters
     ----------
@@ -775,7 +800,22 @@ def unbox(arr: ak.Array | Ragged[DTYPE_co]) -> RagParts[DTYPE_co]:
     n_ragged = 0
     offsets = None
 
-    while isinstance(node, (ListArray, ListOffsetArray, RegularArray, RecordArray)):
+    while isinstance(
+        node,
+        (
+            ListArray,
+            ListOffsetArray,
+            RegularArray,
+            RecordArray,
+            IndexedArray,
+            IndexedOptionArray,
+        ),
+    ):
+        if isinstance(node, (IndexedArray, IndexedOptionArray)):
+            # Ragged carries no missing values; project() collapses the index.
+            # (An option array with real None would drop rows and desync shape[0].)
+            node = node.project()
+            continue
         if isinstance(node, RecordArray):
             raise ValueError(  # noqa: TRY004
                 "Must extract a single field before unboxing a Ragged array of records."

--- a/tests/test_rag_to_packed.py
+++ b/tests/test_rag_to_packed.py
@@ -145,3 +145,45 @@ class TestToPackedMethod:
         import seqpro.rag as rag_mod
 
         assert hasattr(rag_mod, "to_packed")
+
+
+class TestIndexedLayouts:
+    """An IndexedArray wrapper arises from indexing a *record* then pulling a
+    field (e.g. ak.zip(...)[perm]["x"]). seqpro's layout walkers must traverse
+    it. Plain Ragged[perm] yields a ListArray (already covered elsewhere)."""
+
+    def test_indexed_field_unbox_and_to_packed(self):
+        lengths = np.array([3, 0, 2, 4])
+        perm = np.array([2, 0, 3, 1])
+        data = np.arange(int(lengths.sum()), dtype=np.float64)
+        r = Ragged.from_lengths(data, lengths)
+        field = ak.zip({"x": r}, depth_limit=1)[perm]["x"]
+
+        from awkward.contents import IndexedArray
+
+        assert isinstance(field.layout, IndexedArray)
+
+        rag = Ragged(field)  # used to raise: Expected 1 ragged dimension, got 0
+        # accessors that route through unbox() must all work
+        assert rag.offsets is not None
+        assert rag.data is not None
+        out = to_packed(rag)
+        assert out.offsets.ndim == 1 and out.offsets[0] == 0
+        assert out.is_contiguous
+        assert ak.to_list(out) == ak.to_list(field)
+        assert ak.to_list(out) == ak.to_list(ak.to_packed(field))
+
+    def test_indexed_record_layout_offsets(self):
+        # ak.zip(..., depth_limit=1) -> RecordArray; indexing it ->
+        # IndexedArray(RecordArray(...)), which _extract_list_offsets must walk.
+        r = Ragged.from_lengths(np.arange(9, dtype=np.float64), np.array([3, 2, 4]))
+        rec = ak.zip({"a": r, "b": r}, depth_limit=1)[np.array([2, 0, 1])]
+
+        from awkward.contents import IndexedArray
+
+        assert isinstance(rec.layout, IndexedArray)
+
+        rag = Ragged(rec)  # record-layout Ragged over an indexed layout
+        # offsets extraction (via _extract_list_offsets) must not crash
+        assert rag.offsets is not None
+        assert ak.to_list(rag["a"]) == ak.to_list(rec["a"])


### PR DESCRIPTION
## Summary
- `unbox()` and `_extract_list_offsets()` skipped `IndexedArray`/`IndexedOptionArray` in their layout walk, so a `Ragged` over an indexed layout (e.g. `ak.zip(...)[perm][field]`, which arises from fancy-indexing/reversing a record then pulling a field) raised `Expected 1 ragged dimension, got 0` / `No list layer found`.
- Both walkers now `project()` Indexed* nodes (only materializes the index when one is present); added `_is_indexed_record` so `Ragged(IndexedArray(RecordArray(...)))` routes to the record path.
- Docstring corrected: `unbox()` still returns a view — `project()` reorders list pointers into `starts`/`stops`, the flat buffer is shared.

This unblocks downstream `RaggedVariants.to_packed()`/`rc_()` on sliced/reordered views in GenVarLoader.

## Test Plan
- [x] New `TestIndexedLayouts` (indexed-field unbox+to_packed round-trip vs `ak.to_packed`; indexed-record offsets) — 2 tests
- [x] Full `tests/test_rag_to_packed.py` green (16 passed)
- [x] No version bump in the diff — commitizen will bump 0.15.0 → 0.15.1 (patch) on release

🤖 Generated with [Claude Code](https://claude.com/claude-code)