### PR TITLE
ci(publish): make free-threaded (cp314t) wheel builds non-blocking

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -74,6 +74,9 @@ jobs:
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
       - name: Build free-threaded wheels
+        # cp314t free-threaded cross-builds are flaky (QEMU emulation); don't let
+        # a free-threaded build failure block the release of the stable wheels.
+        continue-on-error: true
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
@@ -114,6 +117,9 @@ jobs:
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: musllinux_1_2
       - name: Build free-threaded wheels
+        # cp314t free-threaded cross-builds are flaky (QEMU emulation); don't let
+        # a free-threaded build failure block the release of the stable wheels.
+        continue-on-error: true
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
@@ -159,6 +165,9 @@ jobs:
           python-version: '3.14t'
           architecture: ${{ matrix.platform.python_arch }}
       - name: Build free-threaded wheels
+        # cp314t free-threaded cross-builds are flaky (QEMU emulation); don't let
+        # a free-threaded build failure block the release of the stable wheels.
+        continue-on-error: true
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
@@ -196,6 +205,9 @@ jobs:
         with:
           python-version: '3.14t'
       - name: Build free-threaded wheels
+        # cp314t free-threaded cross-builds are flaky (QEMU emulation); don't let
+        # a free-threaded build failure block the release of the stable wheels.
+        continue-on-error: true
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}


### PR DESCRIPTION
## Summary
- The per-platform `Build free-threaded wheels` steps (`-i python3.14t`) flake intermittently on QEMU-emulated cross-builds (`docker exit 2` / `tar: Error is not recoverable`), on a different ~2 arches each run.
- Because the `release` job `needs:` every build job, a single free-threaded flake blocks the **entire** PyPI upload (it took down the 0.15.1 publish: tagged + GH-released, 0 files on PyPI).
- Add `continue-on-error: true` to the 4 free-threaded build steps so a flake still uploads that platform's stable (cp39-abi3) wheels and the release proceeds. Free-threaded wheels become best-effort until the cp314t toolchain stabilizes.

## Test Plan
- [x] After merge, re-dispatch the release pipeline for tag 0.15.1 (`skip_bump=true`) and confirm 0.15.1 publishes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)