### PR TITLE
perf(tokenize): parallel Numba LUT gather + CodSpeed microbenchmarks

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -1,0 +1,31 @@
+name: Benchmarks
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    name: "Run CodSpeed microbenchmarks"
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          pixi-version: v0.67.2
+          cache: true
+          environments: bench
+          locked: false
+      - name: Build extension
+        run: pixi run -e bench maturin develop
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@v3
+        with:
+          token: ${{ secrets.CODSPEED_TOKEN }}
+          run: pixi run -e bench bench

--- a/docs/superpowers/plans/2026-06-12-tokenize-lut-codspeed.md
+++ b/docs/superpowers/plans/2026-06-12-tokenize-lut-codspeed.md
@@ -1,0 +1,450 @@
+# Tokenize LUT Optimization + CodSpeed Microbenchmarks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `tokenize`'s per-character linear-scan kernel with a 256-entry NumPy lookup-table gather, and add `pytest-codspeed` microbenchmarks wired into a CodSpeed CI workflow.
+
+**Architecture:** `tokenize` builds a 256-entry `int32` LUT (`unknown_token` fill, scattered with the token map) and tokenizes via `np.take(lut, seqs.view(uint8), out=out)` for both dense and Ragged inputs. `gufunc_tokenize` is left untouched because `decode_tokens` (out of scope) still uses it. Benchmarks live in a `test_*` file collected by the normal suite and timed under `--codspeed`. A precomputed-DNA LUT fast path is added only if a benchmark proves it faster.
+
+**Tech Stack:** Python, NumPy, Numba (existing, untouched), pytest, pytest-codspeed, pixi, GitHub Actions, CodSpeed.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-tokenize-lut-codspeed-design.md`
+
+---
+
+## File Structure
+
+- `python/seqpro/_encoders.py` — modify `tokenize` only (the LUT change). `decode_tokens` and all overloads/signatures unchanged.
+- `python/seqpro/_numba.py` — unchanged (`gufunc_tokenize` stays for `decode_tokens`).
+- `tests/test_tokenize.py` — add an equivalence/characterization test guarding the refactor.
+- `tests/test_bench_tokenize.py` — new; `pytest-codspeed` benchmarks (dense + 3 ragged profiles) + the DNA-fast-path comparison.
+- `pixi.toml` — add `pytest-codspeed` to the `bench` feature and a `bench` task.
+- `.github/workflows/bench.yaml` — new CodSpeed CI workflow.
+
+---
+
+## Task 1: Characterization test locking tokenize output (guards the refactor)
+
+This test pins current `tokenize` output to a direct `gufunc_tokenize` reference. It passes against the current implementation AND must keep passing after the LUT change — that is the safety net.
+
+**Files:**
+- Test: `tests/test_tokenize.py` (append)
+
+- [ ] **Step 1: Write the test**
+
+Append to `tests/test_tokenize.py`:
+
+```python
+def test_tokenize_matches_gufunc_reference():
+    """LUT output must be byte-for-byte identical to the linear-scan gufunc."""
+    from seqpro._numba import gufunc_tokenize
+
+    token_map = {"A": 0, "C": 1, "G": 2, "T": 3}
+    unknown_token = 4
+
+    def reference(cast_seq):
+        source = np.array([c.encode("ascii") for c in token_map]).view(np.uint8)
+        target = np.array(list(token_map.values()), dtype=np.int32)
+        return gufunc_tokenize(
+            cast_seq.view(np.uint8), source, target, np.int32(unknown_token)
+        )
+
+    # Dense 2-D, with known + unknown ("N", "x") characters.
+    seqs = ["ACGTN", "TTxAC", "GGGGG"]
+    cast = sp.cast_seqs(seqs)  # (3, 5) S1
+    expected = reference(cast)
+    result = sp.tokenize(cast, token_map, unknown_token=unknown_token)
+    np.testing.assert_array_equal(result, expected)
+    assert result.dtype == np.int32
+
+    # out= path: result written in place, equals expected, returns same buffer.
+    out = np.empty(cast.shape, dtype=np.int32)
+    returned = sp.tokenize(cast, token_map, unknown_token=unknown_token, out=out)
+    np.testing.assert_array_equal(out, expected)
+    np.testing.assert_array_equal(returned, expected)
+
+    # Ragged path.
+    rag_seqs = ["ACGTN", "TTxAC", "GGGGG"]
+    data = np.frombuffer("".join(rag_seqs).encode("ascii"), dtype="S1")
+    lengths = np.array([len(s) for s in rag_seqs])
+    rag = Ragged.from_lengths(data, lengths)
+    rag_result = sp.tokenize(rag, token_map, unknown_token=unknown_token)
+    flat_expected = reference(np.frombuffer(b"".join(s.encode() for s in rag_seqs), dtype="S1"))
+    np.testing.assert_array_equal(rag_result.data, flat_expected)
+    np.testing.assert_array_equal(rag_result.lengths.ravel(), lengths)
+```
+
+- [ ] **Step 2: Run the test to verify it passes against the CURRENT implementation**
+
+Run: `pixi run -e dev pytest tests/test_tokenize.py::test_tokenize_matches_gufunc_reference -v`
+Expected: PASS (current code already produces this output — this confirms the reference is correct).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_tokenize.py
+git commit -m "test: characterize tokenize output against gufunc reference"
+```
+
+---
+
+## Task 2: Replace tokenize's kernel with a 256-entry LUT gather
+
+**Files:**
+- Modify: `python/seqpro/_encoders.py` (function `tokenize`, lines ~239-276 — the body after the docstring only)
+- Test: `tests/test_tokenize.py` (the Task 1 test + existing tests)
+
+- [ ] **Step 1: Verify the existing + characterization tests pass (baseline green)**
+
+Run: `pixi run -e dev pytest tests/test_tokenize.py -v`
+Expected: PASS (all tokenize tests, including `test_tokenize_matches_gufunc_reference`).
+
+- [ ] **Step 2: Rewrite the `tokenize` body**
+
+In `python/seqpro/_encoders.py`, replace the body of `tokenize` BELOW the docstring (currently lines ~264-276, starting at `source = np.array(...)`) with:
+
+```python
+    # Build a 256-entry lookup table: lut[byte] -> token. Input is uint8 (0-255)
+    # after cast_seqs, so a single gather replaces a per-character linear scan.
+    keys = np.array([c.encode("ascii") for c in token_map]).view(np.uint8)
+    vals = np.array(list(token_map.values()), dtype=np.int32)
+    lut = np.full(256, np.int32(unknown_token), dtype=np.int32)
+    lut[keys] = vals
+
+    if isinstance(seqs, Ragged):
+        seqs = seqs.to_packed()
+        n = len(seqs.lengths.ravel())
+        trailing = seqs.data.shape[1:]
+        flat = np.take(lut, seqs.data.view(np.uint8))
+        return Ragged.from_offsets(flat, (n, None, *trailing), seqs.offsets)
+
+    _seqs = cast_seqs(seqs)
+    return np.take(lut, _seqs.view(np.uint8), out=out)
+```
+
+Do NOT modify the docstring, the `@overload` signatures, or `decode_tokens`. Leave the `gufunc_tokenize` import in place (still used by `decode_tokens`).
+
+- [ ] **Step 3: Run the characterization + existing tokenize tests**
+
+Run: `pixi run -e dev pytest tests/test_tokenize.py -v`
+Expected: PASS (identical output to the reference; roundtrip and ragged tests still green).
+
+- [ ] **Step 4: Run the full suite to catch downstream callers (e.g. transforms, ohe roundtrips)**
+
+Run: `pixi run -e dev pytest tests/ -q`
+Expected: PASS (no regressions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/seqpro/_encoders.py
+git commit -m "perf(tokenize): use 256-entry LUT gather instead of linear scan"
+```
+
+---
+
+## Task 3: Add pytest-codspeed dependency and a bench task
+
+**Files:**
+- Modify: `pixi.toml` (`[feature.bench.dependencies]` and `[feature.bench.tasks]`)
+
+- [ ] **Step 1: Add the dependency**
+
+In `pixi.toml`, under `[feature.bench.dependencies]` (currently `marimo`, `seaborn`, `statsmodels`), add:
+
+```toml
+pytest-codspeed = "*"
+```
+
+- [ ] **Step 2: Add the bench task**
+
+In `pixi.toml`, under `[feature.bench.tasks]` (currently has `i-kernel`), add:
+
+```toml
+bench = "pytest tests/test_bench_tokenize.py --codspeed"
+```
+
+- [ ] **Step 3: Install the bench environment**
+
+Run: `pixi install -e bench`
+Expected: resolves and installs `pytest-codspeed` (and its `pytest-benchmark`-compatible API) into the `bench` env.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pixi.toml pixi.lock
+git commit -m "build(bench): add pytest-codspeed and bench task"
+```
+
+---
+
+## Task 4: Write the tokenize microbenchmarks (dense + 3 ragged profiles)
+
+`pytest-codspeed` provides a `benchmark` fixture (pytest-benchmark compatible). Named `test_*` so the default suite collects them — under plain pytest the body runs once (cheap); under `--codspeed` it is instrumented and timed.
+
+**Files:**
+- Create: `tests/test_bench_tokenize.py`
+
+- [ ] **Step 1: Write the benchmark file**
+
+Create `tests/test_bench_tokenize.py`:
+
+```python
+"""Microbenchmarks for ``seqpro.tokenize`` (pytest-codspeed).
+
+Collected by the normal test suite (runs each body once, ~free) and timed under
+``pytest --codspeed`` (see the ``bench`` pixi task / bench.yaml CI workflow).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import seqpro as sp
+from seqpro.rag import Ragged
+
+DNA_TOKEN_MAP = {"A": 0, "C": 1, "G": 2, "T": 3}
+UNKNOWN_TOKEN = 4
+_BASES = np.frombuffer(b"ACGT", dtype="S1")
+
+
+def _rng():
+    # Argless default_rng would be nondeterministic; pin the seed.
+    return np.random.default_rng(0)
+
+
+def _dense(batch: int, length: int) -> np.ndarray:
+    rng = _rng()
+    idx = rng.integers(0, 4, size=(batch, length))
+    return _BASES[idx]  # (batch, length) S1
+
+
+def _ragged(n: int, low: int, high: int) -> Ragged:
+    rng = _rng()
+    lengths = rng.integers(low, high + 1, size=n).astype(np.int64)
+    total = int(lengths.sum())
+    data = _BASES[rng.integers(0, 4, size=total)]
+    return Ragged.from_lengths(data, lengths)
+
+
+def test_bench_dense_batch(benchmark):
+    """Realistic training batch (512, 1024) DNA."""
+    seqs = _dense(512, 1024)
+    benchmark(lambda: sp.tokenize(seqs, DNA_TOKEN_MAP, unknown_token=UNKNOWN_TOKEN))
+
+
+def test_bench_ragged_short_alleles(benchmark):
+    """Thousands of very short sequences (both alleles)."""
+    seqs = _ragged(8000, 1, 4)
+    benchmark(lambda: sp.tokenize(seqs, DNA_TOKEN_MAP, unknown_token=UNKNOWN_TOKEN))
+
+
+def test_bench_ragged_flanked_alleles(benchmark):
+    """Thousands of >10 bp sequences (alleles with flank nucleotides)."""
+    seqs = _ragged(8000, 11, 60)
+    benchmark(lambda: sp.tokenize(seqs, DNA_TOKEN_MAP, unknown_token=UNKNOWN_TOKEN))
+
+
+def test_bench_ragged_cres(benchmark):
+    """Hundreds of 100-200 bp sequences (CREs)."""
+    seqs = _ragged(500, 100, 200)
+    benchmark(lambda: sp.tokenize(seqs, DNA_TOKEN_MAP, unknown_token=UNKNOWN_TOKEN))
+```
+
+- [ ] **Step 2: Verify the benchmarks are collected and pass as plain tests**
+
+Run: `pixi run -e bench pytest tests/test_bench_tokenize.py -v`
+Expected: PASS — 4 tests collected and run (the `benchmark` fixture executes each callable once without `--codspeed`).
+
+- [ ] **Step 3: Verify they run under codspeed instrumentation locally**
+
+Run: `pixi run -e bench pytest tests/test_bench_tokenize.py --codspeed -v`
+Expected: PASS — codspeed reports timing for the 4 benchmarks (a "running in walltime mode / not in CI" notice is fine locally).
+
+- [ ] **Step 4: Confirm the default test suite still passes (benchmarks run as plain tests there too)**
+
+Run: `pixi run -e dev pytest tests/test_bench_tokenize.py -q`
+Expected: PASS (the `benchmark` fixture is provided by pytest-codspeed; if the `dev` env lacks it this file is skipped/errors — if so, the bench file should only be collected in the bench env: see note).
+
+Note: if `dev` env errors on the missing `benchmark` fixture, add `tests/test_bench_tokenize.py` to a `--ignore` for the default `test` task, or guard the import with `pytest.importorskip("pytest_codspeed")` at module top. Prefer `pytest.importorskip` so the file self-skips cleanly:
+
+```python
+pytest.importorskip("pytest_codspeed")
+```
+
+(Place it directly after the imports.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_bench_tokenize.py
+git commit -m "test(bench): add tokenize microbenchmarks (dense + ragged profiles)"
+```
+
+---
+
+## Task 5: DNA fast-path comparison + conditional integration
+
+Add a benchmark comparing the per-call generic LUT against a **precomputed module-level DNA LUT** (built once at import, reused when `token_map` matches canonical DNA). Integrate the precomputed branch into `tokenize` ONLY if the benchmark shows a real, repeatable win; otherwise document the non-win and stop.
+
+**Files:**
+- Modify: `tests/test_bench_tokenize.py` (add comparison benchmarks)
+- Modify (CONDITIONAL on benchmark result): `python/seqpro/_encoders.py`
+
+- [ ] **Step 1: Add the comparison benchmarks**
+
+Append to `tests/test_bench_tokenize.py`:
+
+```python
+# Candidate DNA fast path: a LUT built once at import, reused across calls,
+# avoiding the per-call np.full(256)+scatter. Compared head-to-head below.
+_DNA_LUT = np.full(256, np.int32(UNKNOWN_TOKEN), dtype=np.int32)
+_DNA_LUT[np.frombuffer(b"ACGT", dtype="S1").view(np.uint8)] = np.arange(4, dtype=np.int32)
+
+
+def _generic_tokenize(u8: np.ndarray) -> np.ndarray:
+    keys = np.array([c.encode("ascii") for c in DNA_TOKEN_MAP]).view(np.uint8)
+    vals = np.array(list(DNA_TOKEN_MAP.values()), dtype=np.int32)
+    lut = np.full(256, np.int32(UNKNOWN_TOKEN), dtype=np.int32)
+    lut[keys] = vals
+    return np.take(lut, u8)
+
+
+def test_bench_dna_generic_lut(benchmark):
+    u8 = _dense(512, 1024).view(np.uint8)
+    benchmark(lambda: _generic_tokenize(u8))
+
+
+def test_bench_dna_precomputed_lut(benchmark):
+    u8 = _dense(512, 1024).view(np.uint8)
+    benchmark(lambda: np.take(_DNA_LUT, u8))
+```
+
+- [ ] **Step 2: Run the comparison and record the numbers**
+
+Run: `pixi run -e bench pytest tests/test_bench_tokenize.py -k "dna" --codspeed -v`
+Expected: PASS. Record the two timings. The precomputed LUT only saves the O(256) build; on a (512,1024) batch the gather dominates, so a win is expected to be negligible.
+
+- [ ] **Step 3: Decision gate**
+
+- If `test_bench_dna_precomputed_lut` is **NOT meaningfully faster** (e.g. <5% and within noise): STOP integration. The generic LUT stands. Add a one-line note to the spec's "DNA-specific fast path" section recording the measured non-win, then commit only the benchmark additions:
+
+  ```bash
+  git add tests/test_bench_tokenize.py docs/superpowers/specs/2026-06-12-tokenize-lut-codspeed-design.md
+  git commit -m "test(bench): compare generic vs precomputed DNA LUT (no meaningful win)"
+  ```
+
+- If it **IS meaningfully faster** (repeatable, well outside noise): proceed to Step 4.
+
+- [ ] **Step 4 (CONDITIONAL): Integrate the precomputed DNA LUT**
+
+Only if Step 3 found a real win. In `python/seqpro/_encoders.py`, add a module-level constant near the top (after imports):
+
+```python
+# Precomputed LUT for the canonical DNA token map (fast path for tokenize).
+_DNA_TOKEN_MAP = {"A": 0, "C": 1, "G": 2, "T": 3}
+_DNA_LUT = np.full(256, np.int32(4), dtype=np.int32)
+_DNA_LUT[np.frombuffer(b"ACGT", dtype="S1").view(np.uint8)] = np.arange(4, dtype=np.int32)
+```
+
+Then in `tokenize`, replace the LUT-build block with a fast-path check:
+
+```python
+    if token_map == _DNA_TOKEN_MAP and unknown_token == 4:
+        lut = _DNA_LUT
+    else:
+        keys = np.array([c.encode("ascii") for c in token_map]).view(np.uint8)
+        vals = np.array(list(token_map.values()), dtype=np.int32)
+        lut = np.full(256, np.int32(unknown_token), dtype=np.int32)
+        lut[keys] = vals
+```
+
+- [ ] **Step 5 (CONDITIONAL): Verify correctness unchanged**
+
+Run: `pixi run -e dev pytest tests/test_tokenize.py -v`
+Expected: PASS (`test_tokenize_matches_gufunc_reference` confirms the fast path matches the reference, since it uses the canonical DNA map + unknown_token=4).
+
+- [ ] **Step 6 (CONDITIONAL): Commit**
+
+```bash
+git add python/seqpro/_encoders.py tests/test_bench_tokenize.py
+git commit -m "perf(tokenize): precomputed LUT fast path for canonical DNA token map"
+```
+
+---
+
+## Task 6: CodSpeed CI workflow
+
+**Files:**
+- Create: `.github/workflows/bench.yaml`
+
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/bench.yaml`:
+
+```yaml
+name: Benchmarks
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    name: "Run CodSpeed microbenchmarks"
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          pixi-version: v0.67.2
+          cache: true
+          environments: bench
+          locked: false
+      - name: Build extension
+        run: pixi run -e bench maturin develop
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@v3
+        with:
+          token: ${{ secrets.CODSPEED_TOKEN }}
+          run: pixi run -e bench bench
+```
+
+- [ ] **Step 2: Validate the workflow YAML syntax**
+
+Run: `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/bench.yaml')); print('valid')"`
+Expected: prints `valid`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/bench.yaml
+git commit -m "ci(bench): add CodSpeed benchmark workflow"
+```
+
+- [ ] **Step 4: Manual handoff note (out of repo — user action)**
+
+After merge, the user must: install the **CodSpeed GitHub App** on the repo and add a **`CODSPEED_TOKEN`** repository secret (from codspeed.io). Until then the workflow runs but cannot upload results / comment on PRs. This is not a code step — surface it in the PR description.
+
+---
+
+## Self-Review
+
+- **Spec coverage:**
+  - LUT optimization of `tokenize` only → Task 2. ✓
+  - `gufunc_tokenize`/`decode_tokens` untouched → Task 2 Step 2 explicitly preserves them. ✓
+  - Equivalence/characterization test (dense, ragged, `out=`) → Task 1. ✓
+  - DNA fast path, benchmarked & gated on a real win → Task 5. ✓
+  - Microbenchmarks in `tests/test_bench_tokenize.py` (dense + 3 ragged profiles) → Task 4. ✓
+  - `pytest-codspeed` dep + `bench` task in pixi → Task 3. ✓
+  - `bench.yaml` CodSpeed CI workflow + maturin build → Task 6. ✓
+  - User wires App + `CODSPEED_TOKEN` → Task 6 Step 4. ✓
+  - No `SKILL.md` change (signature/behavior unchanged) → confirmed; no task needed. ✓
+- **Placeholder scan:** No TBD/TODO; all code steps contain full code. The only conditional content (Task 5 Steps 4-6) is explicitly gated and fully specified. ✓
+- **Type/name consistency:** `DNA_TOKEN_MAP`/`UNKNOWN_TOKEN` (bench module) vs `_DNA_TOKEN_MAP`/`_DNA_LUT` (encoders module) are intentionally distinct namespaces; the canonical map `{"A":0,"C":1,"G":2,"T":3}` and `unknown_token == 4` are consistent across Tasks 4-5. `np.take(lut, ..., out=out)` signature consistent with the `out` param of `tokenize`. ✓

--- a/docs/superpowers/specs/2026-06-12-tokenize-lut-codspeed-design.md
+++ b/docs/superpowers/specs/2026-06-12-tokenize-lut-codspeed-design.md
@@ -1,0 +1,178 @@
+# Design: Optimize `tokenize` with a LUT + CodSpeed microbenchmarks
+
+Date: 2026-06-12
+Status: Approved (pending implementation)
+
+## Problem
+
+`seqpro.tokenize` is bottlenecking model training. The forward path runs through
+`gufunc_tokenize` (`python/seqpro/_numba.py`), which tokenizes each character with a
+**per-character linear scan** over the token map's keys:
+
+```python
+res[0] = unknown_token
+for i in range(len(source)):
+    if seq == source[i]:
+        res[0] = target[i]
+        break
+```
+
+This is O(n_chars × alphabet_size) with a branch per comparison. Sequence input is always
+`uint8` bytes (0–255) after `cast_seqs`, so the per-character cost can be made O(1) with a
+fixed 256-entry lookup table.
+
+There is also no microbenchmark guarding tokenize performance, so regressions are invisible
+in CI.
+
+## Scope
+
+- **In scope:** optimize `tokenize` (forward path only); add equivalence test; add
+  `pytest-codspeed` microbenchmarks; add the `bench` tooling; add a CodSpeed CI workflow.
+- **Out of scope:** `decode_tokens`. It reuses `gufunc_tokenize` in reverse (int32 → bytes);
+  that kernel stays exactly as-is and `decode_tokens` is unchanged.
+
+## Approach
+
+**Pure-NumPy LUT gather** (chosen over a Numba LUT gufunc).
+
+Build a 256-entry int32 table once per call and gather:
+
+```python
+lut = np.full(256, unknown_token, dtype=np.int32)
+lut[source_bytes] = target          # source_bytes: uint8 ASCII codes of token_map keys
+out = np.take(lut, seqs.view(np.uint8), out=out)
+```
+
+- Single vectorized, branchless gather — memory-bandwidth bound; the 1 KB table sits in L1.
+- Eliminates a Numba kernel from `tokenize`'s path (faster import, less compiled `.so`/cache
+  surface to maintain).
+- `np.take` natively supports the `out=` argument, preserving the zero-alloc training path.
+- This is **not** "naive NumPy" under CLAUDE.md — a LUT gather is the canonical optimal
+  primitive for byte→int mapping, not a Python loop or per-segment concatenate. The benchmark
+  verifies it beats the alternative.
+
+Rejected alternative — **Numba LUT gufunc** (`res[0] = lut[seq]`, `target="parallel"`): keeps
+the gufunc shape but adds thread-dispatch overhead to a trivial, already-bandwidth-bound op,
+which typically loses to a single `np.take` at these input sizes. Revisit only if a future
+input profile demonstrates otherwise.
+
+### DNA-specific fast path (benchmarked, adopted only if faster)
+
+Consider a specialized path for the common DNA case mapping `A,C,G,T → 0,1,2,3` and everything
+else → `4` (unknown). The benchmark (component 3) will compare it head-to-head against the
+generic LUT, and we adopt it **only if measurably faster** on the dense and ragged profiles.
+
+Expectation (to be confirmed by data, not assumed): it likely will **not** beat the generic
+LUT, because both are bound by the **int32 output write** (4 bytes written per character vs a
+1-byte read), and the generic LUT's input gather is already a single L1-resident table lookup.
+An arithmetic scheme like `(byte >> 1) & 3` is a bijection only on `{A,C,G,T}`, produces the
+wrong code order, and still needs a range check to route non-canonical bytes to `4` — adding
+branches to a path whose cost is dominated by the write. If the benchmark nonetheless shows a
+win, the DNA path is selected automatically when `token_map` matches the canonical DNA mapping
+(`{"A":0,"C":1,"G":2,"T":3}` with `unknown_token == 4`), falling back to the generic LUT
+otherwise; the public signature is unchanged either way. If it does not win, the generic LUT
+stands alone and the comparison benchmark is dropped or left as a documented non-win.
+
+### Preserved assumptions & semantics
+
+- **Single-character ASCII keys** in `token_map`. The existing code already assumes this
+  (`np.array([c.encode("ascii") for c in token_map]).view(np.uint8)` feeding a 1-D `(n)`
+  gufunc signature), so the LUT — indexed by a single byte — preserves it.
+- **Public signature unchanged:** `tokenize(seqs, token_map, unknown_token, out=None)`.
+- **Output dtype** stays `np.int32`.
+- **Unknown chars** map to `unknown_token` (the LUT fill value).
+- **`out=`** supported for dense input only (as today); `np.take(..., out=out)` writes in place.
+- **Ragged path:** same gather over `seqs.to_packed().data`, rebuilt via
+  `Ragged.from_offsets(flat, (n, None, *trailing), seqs.offsets)`.
+
+### LUT rebuild cost
+
+The LUT is rebuilt every call (O(256) fill + O(alphabet) scatter), negligible versus the
+gather over B×L characters. No caching — `token_map` is an unhashable dict and the cost is
+not measurable against real batches (YAGNI).
+
+## Components
+
+### 1. Core change — `python/seqpro/_encoders.py`, `tokenize` only
+
+Replace the `source`/`target`/`gufunc_tokenize` body with LUT construction + `np.take` for
+both the dense and Ragged branches. Do not touch `_numba.gufunc_tokenize` (still used by
+`decode_tokens`) or any overloads/signatures.
+
+### 2. Equivalence test — `tests/test_tokenize.py`
+
+A test asserting the new LUT output is **byte-for-byte identical** to the previous
+`gufunc_tokenize` path. To avoid depending on deleted code, compute the reference inline
+(direct `gufunc_tokenize` call, still importable from `seqpro._numba`) and compare. Cover:
+
+- known characters in the alphabet,
+- unknown characters → `unknown_token`,
+- dense 2-D input,
+- ragged input,
+- dense input with a preallocated `out=` array.
+
+This locks correctness independent of the existing roundtrip tests.
+
+### 3. Microbenchmarks — `tests/test_bench_tokenize.py`
+
+`pytest-codspeed` benchmarks using `@pytest.mark.benchmark`. Named `test_*` so the default
+`pixi run test` collects them (running each body once as a plain test — effectively free) and
+`--codspeed` instruments/times them. Inputs built once per parametrization with a fixed-seed
+`np.random.default_rng`:
+
+- **Dense batch:** `(512, 1024)` DNA (`B × L`) — the shape bottlenecking training.
+- **Ragged — short alleles:** thousands of very short sequences (both alleles).
+- **Ragged — flanked alleles:** thousands of >10 bp sequences (alleles with flank nucleotides).
+- **Ragged — CREs:** hundreds of 100–200 bp sequences.
+
+Each benchmark calls `sp.tokenize(...)` with a DNA token map and a fixed `unknown_token`.
+
+**DNA-fast-path comparison:** include a paired benchmark that times the generic LUT against a
+candidate DNA-specific path on the same inputs, so the data decides whether the specialized
+path is worth keeping (see "DNA-specific fast path" above). Only the winning implementation
+ships in `tokenize`.
+
+### 4. Tooling — `pixi.toml`
+
+- Add `pytest-codspeed` to the `bench` feature dependencies.
+- Add a `bench` task under `[feature.bench.tasks]`, e.g.:
+  `bench = "pytest tests/test_bench_tokenize.py --codspeed"`.
+
+The `--codspeed` flag only times `@pytest.mark.benchmark` tests; plain `pixi run test`
+continues to pass (benchmarks run as ordinary, cheap tests).
+
+### 5. CI — `.github/workflows/bench.yaml`
+
+New workflow, mirroring `test.yaml`'s pixi setup:
+
+- Triggers: `pull_request` to `main` + `workflow_dispatch`.
+- Single job on `ubuntu-latest`, pixi `bench` environment (py313).
+- Steps: checkout → setup-pixi (bench env) → `maturin develop` (build the extension, since the
+  editable install needs the compiled `.so`) → run benchmarks via `CodSpeedHQ/action` invoking
+  the pixi `bench` task.
+- Uses `secrets.CODSPEED_TOKEN`.
+
+**User action (out of repo):** install the CodSpeed GitHub App on the repo and add the
+`CODSPEED_TOKEN` repository secret. Until then the workflow runs but cannot upload results.
+
+### 6. Skill — no change
+
+`skills/seqpro/SKILL.md` is untouched: the public signature and observable behavior of
+`tokenize` are unchanged; this is an internal performance change only.
+
+## Testing strategy
+
+- **Correctness:** the new equivalence test + the existing `test_tokenize.py` roundtrip tests
+  must pass on all Python matrix versions via `pixi run test`.
+- **Performance:** CodSpeed reports per-benchmark timings and flags regressions on PRs once the
+  App/secret are configured.
+
+## Risks
+
+- **`np.take` with multi-dim index + `out=`:** verify `np.take(lut, idx, out=out)` accepts a
+  multi-dimensional `idx` with a matching-shape `out` (it does; out shape must equal idx shape).
+  Covered by the `out=` equivalence test case.
+- **CodSpeed CI without secret:** workflow is harmless but non-reporting until the user wires
+  the App + secret; documented above.
+- **Numba extension build in CI:** the bench job must build the Rust/Numba-backed package
+  (`maturin develop`) before running, matching how other envs install the editable package.

--- a/docs/superpowers/specs/2026-06-12-tokenize-lut-codspeed-design.md
+++ b/docs/superpowers/specs/2026-06-12-tokenize-lut-codspeed-design.md
@@ -33,28 +33,41 @@ in CI.
 
 ## Approach
 
-**Pure-NumPy LUT gather** (chosen over a Numba LUT gufunc).
+**256-entry int32 LUT with dual dispatch** (small inputs: `np.take`; large inputs: parallel
+Numba `lut_gather`).
 
-Build a 256-entry int32 table once per call and gather:
+Build a 256-entry int32 table once per call, then dispatch on element count:
 
 ```python
 lut = np.full(256, unknown_token, dtype=np.int32)
 lut[source_bytes] = target          # source_bytes: uint8 ASCII codes of token_map keys
-out = np.take(lut, seqs.view(np.uint8), out=out)
+
+if u8.size < _TOKENIZE_PARALLEL_THRESHOLD:   # ~40k elements
+    out = np.take(lut, u8, out=out)          # single-threaded, zero dispatch overhead
+else:
+    lut_gather(u8.reshape(-1), lut, out.reshape(-1))  # parallel Numba kernel
 ```
 
-- Single vectorized, branchless gather — memory-bandwidth bound; the 1 KB table sits in L1.
-- Eliminates a Numba kernel from `tokenize`'s path (faster import, less compiled `.so`/cache
-  surface to maintain).
-- `np.take` natively supports the `out=` argument, preserving the zero-alloc training path.
-- This is **not** "naive NumPy" under CLAUDE.md — a LUT gather is the canonical optimal
-  primitive for byte→int mapping, not a Python loop or per-segment concatenate. The benchmark
-  verifies it beats the alternative.
+- The 1 KB LUT sits in L1; the gather itself is memory-bandwidth bound for large inputs.
+- `np.take` wins for small inputs: its zero thread-dispatch overhead beats the parallel
+  kernel's ~96 µs launch floor below ~40k elements.
+- For large inputs (`_TOKENIZE_PARALLEL_THRESHOLD ≈ 40_000`), a single-threaded `np.take`
+  was measured ~20–28% **slower** than the original `gufunc_tokenize` (parallel gufunc) on
+  dense (512×1024) and flanked-allele profiles. A pure `np.take` implementation therefore
+  **regressed** vs the original kernel on the inputs that matter most for training.
+- `lut_gather` (`@nb.njit(parallel=True)` over a flat 1-D buffer) restores and improves on
+  the original: measured ~2.2–5.7× faster than `gufunc_tokenize` across dense and ragged
+  profiles, while the small-input `np.take` path retains its win where thread overhead
+  dominates.
+- `np.take` natively supports `out=`, preserving the zero-alloc dense training path for
+  small inputs; the parallel path allocates its own output buffer.
+- The crossover (`_TOKENIZE_PARALLEL_THRESHOLD = 40_000`) is measured on a 14-core machine;
+  the performance curve is flat near the crossover so the exact value is not sensitive.
 
-Rejected alternative — **Numba LUT gufunc** (`res[0] = lut[seq]`, `target="parallel"`): keeps
-the gufunc shape but adds thread-dispatch overhead to a trivial, already-bandwidth-bound op,
-which typically loses to a single `np.take` at these input sizes. Revisit only if a future
-input profile demonstrates otherwise.
+Note on the earlier rejected alternative: an initial prototype used **only** `np.take` (no
+parallel fallback), described here as "pure-NumPy LUT gather". That prototype was correct and
+beat the old gufunc on small inputs, but was measured ~20–28% slower on large inputs. The
+dual-dispatch design above supersedes it.
 
 ### DNA-specific fast path (benchmarked, adopted only if faster)
 
@@ -138,6 +151,11 @@ Each benchmark calls `sp.tokenize(...)` with a DNA token map and a fixed `unknow
 candidate DNA-specific path on the same inputs, so the data decides whether the specialized
 path is worth keeping (see "DNA-specific fast path" above). Only the winning implementation
 ships in `tokenize`.
+
+**gufunc baseline:** four additional `test_bench_baseline_*` benchmarks time the old
+`gufunc_tokenize` kernel directly on the same inputs (dense (512×1024) and the three ragged
+profiles). This gives CodSpeed a head-to-head baseline so any future regression of the
+LUT-gather impl vs the original kernel surfaces automatically in CI.
 
 ### 4. Tooling — `pixi.toml`
 

--- a/docs/superpowers/specs/2026-06-12-tokenize-lut-codspeed-design.md
+++ b/docs/superpowers/specs/2026-06-12-tokenize-lut-codspeed-design.md
@@ -73,6 +73,13 @@ win, the DNA path is selected automatically when `token_map` matches the canonic
 otherwise; the public signature is unchanged either way. If it does not win, the generic LUT
 stands alone and the comparison benchmark is dropped or left as a documented non-win.
 
+**Measured result (2026-06-12, macOS, dense (512,1024) input):** No meaningful win. Over 3
+runs the "best time" was 38–41µs for both paths and the winner flipped between runs (run 1:
+generic=41.16µs, precomputed=38.09µs; run 2: generic=38.97µs, precomputed=40.49µs; run 3:
+generic=40.36µs, precomputed=38.87µs). The 2–7% swings are within the reported 5–8% relative
+StdDev — entirely noise. The gather dominates; skipping the O(256) LUT build saves nothing
+measurable. **Decision: generic LUT stands; DNA fast path not integrated.**
+
 ### Preserved assumptions & semantics
 
 - **Single-character ASCII keys** in `token_map`. The existing code already assumes this

--- a/pixi.lock
+++ b/pixi.lock
@@ -189,6 +189,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/4f/1195bbac8e0c2acc5f740661631d8d750dc38d4a32b23ee5df3cde6f4e0d/joblib-1.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/89/35ea267fb12e608529f0df315aff200171e555623cb38b2e4444592ce872/pyranges-0.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl
@@ -198,6 +199,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a3/e3/16bd2cc9ab2fe458560f8ef7cef513fb5914c70bfd3432c3454e27ae0018/dinuc_shuf-0.1.0b1-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/4a/dfd43d943fdb143be4fd62f34c2793ba349dc27aa188e521d19d629aa7ab/pytest_codspeed-5.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -387,6 +391,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/89/35ea267fb12e608529f0df315aff200171e555623cb38b2e4444592ce872/pyranges-0.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/91/97/1c41d1f5a19f241d8069f1e249853bcce378cdb76eec8ab636d7bc426280/pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl
@@ -396,11 +401,14 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/2c/44d47df76193b31fa4a7c662531076e6ec9a0f2f3017171f47c466211537/pyfaidx-0.9.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c6/3e/48599a38009ca60ff82a6f38c8a621ce3c0286aa7397c7d79e741bd9060e/polars_runtime_32-1.40.1-cp310-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/cf/f4/672930ad51bbc135f51cac89577155f1d0c2d120375fc77978d3aa071bb7/pybigwig-0.3.25.tar.gz
       - pypi: https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/1f/9be29e34615a4325a0ff6da18c55994cb546dcff4423c91f80f101a9858c/logomaker-0.8.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/8e/e032451e9e0a06b0c4bff53105f62b693d9a54595dd8c024693741ce3380/pytest_codspeed-5.0.3-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ea/91/74fc60d94488685a92ac9d49d7ec55f3e91fe9b77942a6235a5fa7f249c3/polars-1.40.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl
@@ -10408,6 +10416,15 @@ packages:
   version: 3.29.0
   sha256: 96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
+  name: rich
+  version: 15.0.0
+  sha256: 33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb
+  requires_dist:
+  - ipywidgets>=7.5.1,<9 ; extra == 'jupyter'
+  - markdown-it-py>=2.2.0
+  - pygments>=2.13.0,<3.0.0
+  requires_python: '>=3.9.0'
 - pypi: https://files.pythonhosted.org/packages/83/89/35ea267fb12e608529f0df315aff200171e555623cb38b2e4444592ce872/pyranges-0.1.4-py3-none-any.whl
   name: pyranges
   version: 0.1.4
@@ -10694,15 +10711,65 @@ packages:
   version: 24.0.0
   sha256: 7c2b98645d576a0b9616892ead22b64a83a5f043c5e2ca15ebcefcb5b70c80cb
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/a6/4a/dfd43d943fdb143be4fd62f34c2793ba349dc27aa188e521d19d629aa7ab/pytest_codspeed-5.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: pytest-codspeed
+  version: 5.0.3
+  sha256: a4bcdb4b6522738152885ef067e0c8524d5699828d780fb6f464cdb3db44369c
+  requires_dist:
+  - pytest>=3.8
+  - rich>=13.8.1
+  - importlib-metadata>=8.5.0 ; python_full_version < '3.10'
+  - pytest-benchmark~=5.0.0 ; extra == 'compat'
+  - pytest-xdist~=3.6.1 ; extra == 'compat'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl
   name: jupyterlab-widgets
   version: 3.0.16
   sha256: 45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8
   requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+  name: mdurl
+  version: 0.1.2
+  sha256: 84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl
   name: pyarrow
   version: 24.0.0
   sha256: 6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
+  name: markdown-it-py
+  version: 4.2.0
+  sha256: 9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a
+  requires_dist:
+  - mdurl~=0.1
+  - psutil ; extra == 'benchmarking'
+  - pytest ; extra == 'benchmarking'
+  - pytest-benchmark ; extra == 'benchmarking'
+  - commonmark~=0.9 ; extra == 'compare'
+  - markdown~=3.4 ; extra == 'compare'
+  - mistletoe~=1.0 ; extra == 'compare'
+  - mistune~=3.0 ; extra == 'compare'
+  - panflute~=2.3 ; extra == 'compare'
+  - markdown-it-pyrs ; extra == 'compare'
+  - linkify-it-py>=1,<3 ; extra == 'linkify'
+  - mdit-py-plugins>=0.5.0 ; extra == 'plugins'
+  - gprof2dot ; extra == 'profiling'
+  - mdit-py-plugins>=0.5.0 ; extra == 'rtd'
+  - myst-parser ; extra == 'rtd'
+  - pyyaml ; extra == 'rtd'
+  - sphinx ; extra == 'rtd'
+  - sphinx-copybutton ; extra == 'rtd'
+  - sphinx-design ; extra == 'rtd'
+  - sphinx-book-theme~=1.0 ; extra == 'rtd'
+  - jupyter-sphinx ; extra == 'rtd'
+  - ipykernel ; extra == 'rtd'
+  - coverage ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - pytest-regressions ; extra == 'testing'
+  - pytest-timeout ; extra == 'testing'
+  - requests ; extra == 'testing'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl
   name: pyarrow
@@ -10971,6 +11038,17 @@ packages:
   version: 12.8.4.1
   sha256: 8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/dc/8e/e032451e9e0a06b0c4bff53105f62b693d9a54595dd8c024693741ce3380/pytest_codspeed-5.0.3-cp313-cp313-macosx_11_0_arm64.whl
+  name: pytest-codspeed
+  version: 5.0.3
+  sha256: 6524c57fec279a22ffef6112af404036afc71b4704758ae9f0abda429b8478d4
+  requires_dist:
+  - pytest>=3.8
+  - rich>=13.8.1
+  - importlib-metadata>=8.5.0 ; python_full_version < '3.10'
+  - pytest-benchmark~=5.0.0 ; extra == 'compat'
+  - pytest-xdist~=3.6.1 ; extra == 'compat'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
   name: typing-inspection
   version: 0.4.2

--- a/pixi.toml
+++ b/pixi.toml
@@ -83,9 +83,11 @@ tangermeme = "*"
 dinuc-shuf = "*"
 ipykernel = "*"
 ipywidgets = "*"
+pytest-codspeed = "*"
 
 [feature.bench.tasks]
 i-kernel = "ipython kernel install --user --name seqpro-bench"
+bench = "pytest tests/test_bench_tokenize.py --codspeed"
 
 [feature.bench.dependencies]
 marimo = ">=0.23.5,<0.24"

--- a/python/seqpro/_encoders.py
+++ b/python/seqpro/_encoders.py
@@ -261,19 +261,22 @@ def tokenize(
     NDArray[np.int32] | Ragged[np.int32]
         Integer token IDs with the same shape/layout as the input.
     """
-    source = np.array([c.encode("ascii") for c in token_map]).view(np.uint8)
-    target = np.array(list(token_map.values()), dtype=np.int32)
-    _unknown_token = np.int32(unknown_token)
+    # Build a 256-entry lookup table: lut[byte] -> token. Input is uint8 (0-255)
+    # after cast_seqs, so a single gather replaces a per-character linear scan.
+    keys = np.array([c.encode("ascii") for c in token_map]).view(np.uint8)
+    vals = np.array(list(token_map.values()), dtype=np.int32)
+    lut = np.full(256, np.int32(unknown_token), dtype=np.int32)
+    lut[keys] = vals
 
     if isinstance(seqs, Ragged):
         seqs = seqs.to_packed()
         n = len(seqs.lengths.ravel())
         trailing = seqs.data.shape[1:]
-        flat = gufunc_tokenize(seqs.data.view(np.uint8), source, target, _unknown_token)
+        flat = np.take(lut, seqs.data.view(np.uint8))
         return Ragged.from_offsets(flat, (n, None, *trailing), seqs.offsets)
 
     _seqs = cast_seqs(seqs)
-    return gufunc_tokenize(_seqs.view(np.uint8), source, target, _unknown_token, out)
+    return np.take(lut, _seqs.view(np.uint8), out=out)
 
 
 @overload

--- a/python/seqpro/_encoders.py
+++ b/python/seqpro/_encoders.py
@@ -268,6 +268,8 @@ def tokenize(
     NDArray[np.int32] | Ragged[np.int32]
         Integer token IDs with the same shape/layout as the input.
     """
+    if out is not None and out.dtype != np.int32:
+        raise TypeError(f"out must have dtype int32, got {out.dtype}.")
     # Build a 256-entry lookup table: lut[byte] -> token. Tokenizing is then a
     # gather, lut[seqs]. Small inputs use single-threaded np.take; larger inputs
     # use a parallel Numba gather that overtakes it past _TOKENIZE_PARALLEL_THRESHOLD.

--- a/python/seqpro/_encoders.py
+++ b/python/seqpro/_encoders.py
@@ -9,10 +9,16 @@ from ._numba import (
     gufunc_pad_both,
     gufunc_pad_left,
     gufunc_tokenize,
+    lut_gather,
 )
 from ._utils import SeqType, StrSeqType, array_slice, cast_seqs, check_axes
 from .alphabets._alphabets import AminoAlphabet, NucleotideAlphabet
 from .rag import Ragged
+
+# Element-count crossover where the parallel LUT gather (~96µs thread-launch
+# floor) overtakes single-threaded np.take. Measured ~40k on a 14-core machine;
+# the curve is flat near the crossover so the exact value is not sensitive.
+_TOKENIZE_PARALLEL_THRESHOLD = 40_000
 
 
 def pad_seqs(
@@ -262,8 +268,9 @@ def tokenize(
     NDArray[np.int32] | Ragged[np.int32]
         Integer token IDs with the same shape/layout as the input.
     """
-    # Build a 256-entry lookup table: lut[byte] -> token. Input is uint8 (0-255)
-    # after cast_seqs, so a single gather replaces a per-character linear scan.
+    # Build a 256-entry lookup table: lut[byte] -> token. Tokenizing is then a
+    # gather, lut[seqs]. Small inputs use single-threaded np.take; larger inputs
+    # use a parallel Numba gather that overtakes it past _TOKENIZE_PARALLEL_THRESHOLD.
     keys = np.array([c.encode("ascii") for c in token_map]).view(np.uint8)
     vals = np.array(list(token_map.values()), dtype=np.int32)
     lut = np.full(256, np.int32(unknown_token), dtype=np.int32)
@@ -273,11 +280,25 @@ def tokenize(
         seqs = seqs.to_packed()
         n = len(seqs.lengths.ravel())
         trailing = seqs.data.shape[1:]
-        flat = np.take(lut, seqs.data.view(np.uint8))
+        u8 = seqs.data.view(np.uint8)
+        if u8.size < _TOKENIZE_PARALLEL_THRESHOLD:
+            flat = np.take(lut, u8)
+        else:
+            flat = np.empty(u8.shape, dtype=np.int32)
+            lut_gather(np.ascontiguousarray(u8).reshape(-1), lut, flat.reshape(-1))
         return Ragged.from_offsets(flat, (n, None, *trailing), seqs.offsets)
 
     _seqs = cast_seqs(seqs)
-    return np.take(lut, _seqs.view(np.uint8), out=out)
+    u8 = _seqs.view(np.uint8)
+    # A strided out= can't be flattened to a writable view, so it takes the
+    # np.take path (which handles arbitrary strides) regardless of size.
+    if u8.size < _TOKENIZE_PARALLEL_THRESHOLD or (
+        out is not None and not out.flags.c_contiguous
+    ):
+        return np.take(lut, u8, out=out)
+    result = out if out is not None else np.empty(u8.shape, dtype=np.int32)
+    lut_gather(np.ascontiguousarray(u8).reshape(-1), lut, result.reshape(-1))
+    return result
 
 
 @overload

--- a/python/seqpro/_encoders.py
+++ b/python/seqpro/_encoders.py
@@ -255,6 +255,7 @@ def tokenize(
         Token to use for unknown values.
     out
         Output array to store the result in. Only valid for non-Ragged input.
+        Must have dtype ``np.int32``; any other dtype raises ``TypeError``.
 
     Returns
     -------

--- a/python/seqpro/_numba.py
+++ b/python/seqpro/_numba.py
@@ -166,6 +166,21 @@ def gufunc_translate(
             break
 
 
+@nb.njit("void(u1[::1], i4[::1], i4[::1])", parallel=True, cache=True)
+def lut_gather(
+    seq: NDArray[np.uint8],
+    lut: NDArray[np.int32],
+    out: NDArray[np.int32],
+) -> None:
+    """Parallel LUT gather over a flat buffer: ``out[i] = lut[seq[i]]``.
+
+    All three arrays must be 1-D and C-contiguous. Used by ``tokenize`` for
+    inputs large enough to amortize thread-launch overhead.
+    """
+    for i in nb.prange(seq.shape[0]):  # type: ignore[not-iterable]
+        out[i] = lut[seq[i]]
+
+
 @nb.njit(cache=True)
 def _pack_codon_index(b0: int, b1: int, b2: int) -> int:
     """Pack a 3-codon's ASCII bytes into a 6-bit LUT index in ``[0, 63]``.

--- a/python/seqpro/_numba.py
+++ b/python/seqpro/_numba.py
@@ -166,7 +166,7 @@ def gufunc_translate(
             break
 
 
-@nb.njit("void(u1[::1], i4[::1], i4[::1])", parallel=True, cache=True)
+@nb.njit(parallel=True, cache=True)
 def lut_gather(
     seq: NDArray[np.uint8],
     lut: NDArray[np.int32],

--- a/tests/test_bench_tokenize.py
+++ b/tests/test_bench_tokenize.py
@@ -1,0 +1,61 @@
+"""Microbenchmarks for ``seqpro.tokenize`` (pytest-codspeed).
+
+Collected by the normal test suite (runs each body once, ~free) and timed under
+``pytest --codspeed`` (see the ``bench`` pixi task / bench.yaml CI workflow).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import seqpro as sp
+from seqpro.rag import Ragged
+
+pytest.importorskip("pytest_codspeed")
+
+DNA_TOKEN_MAP = {"A": 0, "C": 1, "G": 2, "T": 3}
+UNKNOWN_TOKEN = 4
+_BASES = np.frombuffer(b"ACGT", dtype="S1")
+
+
+def _rng():
+    # Argless default_rng would be nondeterministic; pin the seed.
+    return np.random.default_rng(0)
+
+
+def _dense(batch: int, length: int) -> np.ndarray:
+    rng = _rng()
+    idx = rng.integers(0, 4, size=(batch, length))
+    return _BASES[idx]  # (batch, length) S1
+
+
+def _ragged(n: int, low: int, high: int) -> Ragged:
+    rng = _rng()
+    lengths = rng.integers(low, high + 1, size=n).astype(np.int64)
+    total = int(lengths.sum())
+    data = _BASES[rng.integers(0, 4, size=total)]
+    return Ragged.from_lengths(data, lengths)
+
+
+def test_bench_dense_batch(benchmark):
+    """Realistic training batch (512, 1024) DNA."""
+    seqs = _dense(512, 1024)
+    benchmark(lambda: sp.tokenize(seqs, DNA_TOKEN_MAP, unknown_token=UNKNOWN_TOKEN))
+
+
+def test_bench_ragged_short_alleles(benchmark):
+    """Thousands of very short sequences (both alleles)."""
+    seqs = _ragged(8000, 1, 4)
+    benchmark(lambda: sp.tokenize(seqs, DNA_TOKEN_MAP, unknown_token=UNKNOWN_TOKEN))
+
+
+def test_bench_ragged_flanked_alleles(benchmark):
+    """Thousands of >10 bp sequences (alleles with flank nucleotides)."""
+    seqs = _ragged(8000, 11, 60)
+    benchmark(lambda: sp.tokenize(seqs, DNA_TOKEN_MAP, unknown_token=UNKNOWN_TOKEN))
+
+
+def test_bench_ragged_cres(benchmark):
+    """Hundreds of 100-200 bp sequences (CREs)."""
+    seqs = _ragged(500, 100, 200)
+    benchmark(lambda: sp.tokenize(seqs, DNA_TOKEN_MAP, unknown_token=UNKNOWN_TOKEN))

--- a/tests/test_bench_tokenize.py
+++ b/tests/test_bench_tokenize.py
@@ -59,3 +59,29 @@ def test_bench_ragged_cres(benchmark):
     """Hundreds of 100-200 bp sequences (CREs)."""
     seqs = _ragged(500, 100, 200)
     benchmark(lambda: sp.tokenize(seqs, DNA_TOKEN_MAP, unknown_token=UNKNOWN_TOKEN))
+
+
+# Candidate DNA fast path: a LUT built once at import, reused across calls,
+# avoiding the per-call np.full(256)+scatter. Compared head-to-head below.
+_DNA_LUT = np.full(256, np.int32(UNKNOWN_TOKEN), dtype=np.int32)
+_DNA_LUT[np.frombuffer(b"ACGT", dtype="S1").view(np.uint8)] = np.arange(
+    4, dtype=np.int32
+)
+
+
+def _generic_tokenize(u8: np.ndarray) -> np.ndarray:
+    keys = np.array([c.encode("ascii") for c in DNA_TOKEN_MAP]).view(np.uint8)
+    vals = np.array(list(DNA_TOKEN_MAP.values()), dtype=np.int32)
+    lut = np.full(256, np.int32(UNKNOWN_TOKEN), dtype=np.int32)
+    lut[keys] = vals
+    return np.take(lut, u8)
+
+
+def test_bench_dna_generic_lut(benchmark):
+    u8 = _dense(512, 1024).view(np.uint8)
+    benchmark(lambda: _generic_tokenize(u8))
+
+
+def test_bench_dna_precomputed_lut(benchmark):
+    u8 = _dense(512, 1024).view(np.uint8)
+    benchmark(lambda: np.take(_DNA_LUT, u8))

--- a/tests/test_bench_tokenize.py
+++ b/tests/test_bench_tokenize.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 import seqpro as sp
+from seqpro._numba import gufunc_tokenize
 from seqpro.rag import Ragged
 
 pytest.importorskip("pytest_codspeed")
@@ -85,3 +86,34 @@ def test_bench_dna_generic_lut(benchmark):
 def test_bench_dna_precomputed_lut(benchmark):
     u8 = _dense(512, 1024).view(np.uint8)
     benchmark(lambda: np.take(_DNA_LUT, u8))
+
+
+# --- Baseline: the original parallel gufunc kernel, timed on the same inputs so
+# CodSpeed flags any regression of the LUT-gather impl vs the old kernel. ---
+_SOURCE = np.array([c.encode("ascii") for c in DNA_TOKEN_MAP]).view(np.uint8)
+_TARGET = np.array(list(DNA_TOKEN_MAP.values()), dtype=np.int32)
+
+
+def _gufunc(u8: np.ndarray) -> np.ndarray:
+    return gufunc_tokenize(u8, _SOURCE, _TARGET, np.int32(UNKNOWN_TOKEN))
+
+
+def test_bench_baseline_dense_batch(benchmark):
+    """Old gufunc kernel on the dense (512, 1024) batch (baseline)."""
+    u8 = _dense(512, 1024).view(np.uint8)
+    benchmark(lambda: _gufunc(u8))
+
+
+def test_bench_baseline_ragged_short_alleles(benchmark):
+    u8 = _ragged(8000, 1, 4).to_packed().data.view(np.uint8)
+    benchmark(lambda: _gufunc(u8))
+
+
+def test_bench_baseline_ragged_flanked_alleles(benchmark):
+    u8 = _ragged(8000, 11, 60).to_packed().data.view(np.uint8)
+    benchmark(lambda: _gufunc(u8))
+
+
+def test_bench_baseline_ragged_cres(benchmark):
+    u8 = _ragged(500, 100, 200).to_packed().data.view(np.uint8)
+    benchmark(lambda: _gufunc(u8))

--- a/tests/test_bench_tokenize.py
+++ b/tests/test_bench_tokenize.py
@@ -105,15 +105,17 @@ def test_bench_baseline_dense_batch(benchmark):
 
 
 def test_bench_baseline_ragged_short_alleles(benchmark):
-    u8 = _ragged(8000, 1, 4).to_packed().data.view(np.uint8)
-    benchmark(lambda: _gufunc(u8))
+    # Pack inside the timed callable so the baseline pays the same to_packed()
+    # copy the real ragged tokenize path does (fair head-to-head).
+    seqs = _ragged(8000, 1, 4)
+    benchmark(lambda: _gufunc(seqs.to_packed().data.view(np.uint8)))
 
 
 def test_bench_baseline_ragged_flanked_alleles(benchmark):
-    u8 = _ragged(8000, 11, 60).to_packed().data.view(np.uint8)
-    benchmark(lambda: _gufunc(u8))
+    seqs = _ragged(8000, 11, 60)
+    benchmark(lambda: _gufunc(seqs.to_packed().data.view(np.uint8)))
 
 
 def test_bench_baseline_ragged_cres(benchmark):
-    u8 = _ragged(500, 100, 200).to_packed().data.view(np.uint8)
-    benchmark(lambda: _gufunc(u8))
+    seqs = _ragged(500, 100, 200)
+    benchmark(lambda: _gufunc(seqs.to_packed().data.view(np.uint8)))

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -145,3 +145,44 @@ def test_decode_tokens_ragged_module_level():
 
     assert isinstance(result, Ragged)
     np.testing.assert_array_equal(result.data, rag.data)
+
+
+def test_tokenize_matches_gufunc_reference():
+    """LUT output must be byte-for-byte identical to the linear-scan gufunc."""
+    from seqpro._numba import gufunc_tokenize
+
+    token_map = {"A": 0, "C": 1, "G": 2, "T": 3}
+    unknown_token = 4
+
+    def reference(cast_seq):
+        source = np.array([c.encode("ascii") for c in token_map]).view(np.uint8)
+        target = np.array(list(token_map.values()), dtype=np.int32)
+        return gufunc_tokenize(
+            cast_seq.view(np.uint8), source, target, np.int32(unknown_token)
+        )
+
+    # Dense 2-D, with known + unknown ("N", "x") characters.
+    seqs = ["ACGTN", "TTxAC", "GGGGG"]
+    cast = sp.cast_seqs(seqs)  # (3, 5) S1
+    expected = reference(cast)
+    result = sp.tokenize(cast, token_map, unknown_token=unknown_token)
+    np.testing.assert_array_equal(result, expected)
+    assert result.dtype == np.int32
+
+    # out= path: result written in place, equals expected, returns same buffer.
+    out = np.empty(cast.shape, dtype=np.int32)
+    returned = sp.tokenize(cast, token_map, unknown_token=unknown_token, out=out)
+    np.testing.assert_array_equal(out, expected)
+    np.testing.assert_array_equal(returned, expected)
+
+    # Ragged path.
+    rag_seqs = ["ACGTN", "TTxAC", "GGGGG"]
+    data = np.frombuffer("".join(rag_seqs).encode("ascii"), dtype="S1")
+    lengths = np.array([len(s) for s in rag_seqs])
+    rag = Ragged.from_lengths(data, lengths)
+    rag_result = sp.tokenize(rag, token_map, unknown_token=unknown_token)
+    flat_expected = reference(
+        np.frombuffer(b"".join(s.encode() for s in rag_seqs), dtype="S1")
+    )
+    np.testing.assert_array_equal(rag_result.data, flat_expected)
+    np.testing.assert_array_equal(rag_result.lengths.ravel(), lengths)

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -205,3 +205,58 @@ def test_tokenize_out_requires_int32():
     out_i64 = np.empty(cast.shape, dtype=np.int64)
     with pytest.raises(TypeError):
         sp.tokenize(cast, token_map, unknown_token=-1, out=out_i64)
+
+
+def test_tokenize_parallel_branch_matches_reference():
+    """Inputs above the parallel threshold must match the gufunc reference,
+    across writable/readonly, dense/ragged, and out= variants (regression guard
+    for the parallel lut_gather path)."""
+    from seqpro._numba import gufunc_tokenize
+    from seqpro._encoders import _TOKENIZE_PARALLEL_THRESHOLD as THRESH
+
+    token_map = {"A": 0, "C": 1, "G": 2, "T": 3}
+    src = np.array([c.encode("ascii") for c in token_map]).view(np.uint8)
+    tgt = np.array(list(token_map.values()), dtype=np.int32)
+
+    def ref(u8):
+        return gufunc_tokenize(u8, src, tgt, np.int32(4))
+
+    n = THRESH + 5000  # comfortably above the parallel threshold
+    rng = np.random.default_rng(0)
+    bases = np.frombuffer(b"ACGTN", dtype="S1")
+    flat = bases[rng.integers(0, 5, n)]  # (n,) S1, writable, known + unknown
+
+    # writable dense -> parallel kernel
+    np.testing.assert_array_equal(
+        sp.tokenize(flat, token_map, unknown_token=4), ref(flat.view(np.uint8))
+    )
+
+    # readonly dense -> regression guard (np.frombuffer yields a readonly buffer)
+    ro = np.frombuffer(flat.tobytes(), dtype="S1")
+    assert not ro.flags.writeable
+    np.testing.assert_array_equal(
+        sp.tokenize(ro, token_map, unknown_token=4), ref(ro.view(np.uint8))
+    )
+
+    # contiguous int32 out= -> writes through, returns same buffer
+    out = np.empty(n, dtype=np.int32)
+    ret = sp.tokenize(flat, token_map, unknown_token=4, out=out)
+    assert ret is out
+    np.testing.assert_array_equal(out, ref(flat.view(np.uint8)))
+
+    # strided int32 out= -> forced down the np.take fallback, still correct
+    strided = np.empty((n, 2), dtype=np.int32)[:, 0]
+    assert not strided.flags.c_contiguous
+    sp.tokenize(flat, token_map, unknown_token=4, out=strided)
+    np.testing.assert_array_equal(strided, ref(flat.view(np.uint8)))
+
+    # non-int32 out= -> TypeError on the large path too (contract is uniform)
+    with pytest.raises(TypeError):
+        sp.tokenize(flat, token_map, unknown_token=4, out=np.empty(n, dtype=np.int64))
+
+    # ragged above threshold -> parallel kernel on the packed flat data
+    lengths = np.full(2000, 35)  # 70k total elements
+    data = bases[rng.integers(0, 5, int(lengths.sum()))]
+    rag = Ragged.from_lengths(data, lengths)
+    rag_got = sp.tokenize(rag, token_map, unknown_token=4)
+    np.testing.assert_array_equal(rag_got.data, ref(data.view(np.uint8)))

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import numpy as np
+import pytest
 import seqpro as sp
 from hypothesis import given, note
 from seqpro.rag import Ragged
@@ -187,3 +188,20 @@ def test_tokenize_matches_gufunc_reference():
     )
     np.testing.assert_array_equal(rag_result.data, flat_expected)
     np.testing.assert_array_equal(rag_result.lengths.ravel(), lengths)
+
+
+def test_tokenize_out_requires_int32():
+    """out= must be dtype int32; any other dtype raises TypeError."""
+    token_map = {"A": 0, "C": 1, "G": 2, "T": 3}
+    cast = sp.cast_seqs(["ACGT"])
+
+    # int32 out: should write into the buffer and return the same object.
+    out_i32 = np.empty(cast.shape, dtype=np.int32)
+    returned = sp.tokenize(cast, token_map, unknown_token=-1, out=out_i32)
+    np.testing.assert_array_equal(returned, [[0, 1, 2, 3]])
+    assert returned is out_i32
+
+    # non-int32 out: np.take enforces safe casting, so this must raise TypeError.
+    out_i64 = np.empty(cast.shape, dtype=np.int64)
+    with pytest.raises(TypeError):
+        sp.tokenize(cast, token_map, unknown_token=-1, out=out_i64)

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -174,6 +174,7 @@ def test_tokenize_matches_gufunc_reference():
     returned = sp.tokenize(cast, token_map, unknown_token=unknown_token, out=out)
     np.testing.assert_array_equal(out, expected)
     np.testing.assert_array_equal(returned, expected)
+    assert returned is out  # out= must return the same buffer
 
     # Ragged path.
     rag_seqs = ["ACGTN", "TTxAC", "GGGGG"]
@@ -182,7 +183,7 @@ def test_tokenize_matches_gufunc_reference():
     rag = Ragged.from_lengths(data, lengths)
     rag_result = sp.tokenize(rag, token_map, unknown_token=unknown_token)
     flat_expected = reference(
-        np.frombuffer(b"".join(s.encode() for s in rag_seqs), dtype="S1")
+        np.frombuffer(b"".join(s.encode("ascii") for s in rag_seqs), dtype="S1")
     )
     np.testing.assert_array_equal(rag_result.data, flat_expected)
     np.testing.assert_array_equal(rag_result.lengths.ravel(), lengths)


### PR DESCRIPTION
## Summary

Speeds up `tokenize` and adds CodSpeed microbenchmarks.

**The optimization.** `tokenize` builds a 256-entry int32 LUT and gathers `lut[seqs]`, dispatched by input size:
- **< ~40k elements** → single-threaded `np.take` (zero thread-launch overhead wins on small inputs).
- **≥ ~40k elements** → a parallel Numba kernel `lut_gather` (`target`-parallel `prange`), which scales across cores.

This beats the original `target="parallel"` `gufunc_tokenize` across the board (full end-to-end calls, 14-core machine, output verified byte-identical):

| profile | old gufunc tokenize | new tokenize | speedup |
|---|--:|--:|--:|
| dense 512×1024 | 943 µs | 165 µs | **5.7×** |
| ragged short 8000×[1–4] | 325 µs | 239 µs | **1.36×** |
| ragged flank 8000×[11–60] | 778 µs | 341 µs | **2.28×** |
| ragged CRE 500×[100–200] | 397 µs | 276 µs | **1.44×** |

`gufunc_tokenize` is retained (still used by `decode_tokens`). Output is byte-for-byte identical to the old kernel, guarded by a characterization test.

**Why not pure `np.take`?** An earlier iteration replaced the kernel with `np.take` alone. Benchmarking against the *old parallel gufunc* revealed it actually **regressed** large inputs 20–28% (single-threaded gather vs the old multi-threaded kernel). The parallel `lut_gather` fixes that while keeping the small-input win. The benchmark suite now includes a **gufunc baseline** on the same inputs so a regression like this can't slip past CodSpeed again.

**Correctness / contract.** A parallel-branch test exercises ≥40k inputs across writable/readonly, dense/Ragged, and `out=` variants (a readonly-input case is a regression guard — the kernel must accept readonly buffers like `np.frombuffer`). The `out=` argument must be `int32`; a front-loaded guard raises `TypeError` uniformly on both dispatch paths.

## What's in the branch
- `perf(tokenize)`: parallel `lut_gather` kernel + size-dispatched hybrid; readonly-safe; int32-`out=` guard.
- Characterization + contract tests (byte-identical guard, int32 `out=`, parallel-branch matrix).
- `pytest-codspeed` dep + `bench` pixi task; microbenchmarks (dense + 3 ragged profiles) + gufunc baselines.
- CodSpeed CI workflow `.github/workflows/bench.yaml`.
- Design spec updated to the final dual-dispatch design.

No public signature/behavior change (output identical) → no `skills/seqpro/SKILL.md` update required.

## Test Plan
- [x] `pytest tests/test_tokenize.py` — 11 passed (gufunc-equivalence, int32 `out=` contract, parallel-branch matrix incl. readonly)
- [x] Full suite: 356 passed; the 3 failures in `test_ragged_rc.py` / `test_ragged_to_padded.py` are **pre-existing** (`awkward`/`pyarrow.lib.PyExtensionType` version incompatibility, unrelated — fail identically on the parent commit)
- [x] `pixi run -e bench pytest tests/test_bench_tokenize.py` — 10 passed (plain) and under `--codspeed`

## ⚠️ Required out-of-repo follow-up (CodSpeed)
The benchmark workflow runs but cannot upload results / comment on PRs until:
1. The **CodSpeed GitHub App** is installed on this repository.
2. A **`CODSPEED_TOKEN`** repository secret is added (from codspeed.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)