### PR TITLE
feat(tokenize): add parallel escape hatch overriding the size heuristic

### DIFF
--- a/python/seqpro/_encoders.py
+++ b/python/seqpro/_encoders.py
@@ -234,6 +234,8 @@ def tokenize(
     token_map: dict[str, int],
     unknown_token: int,
     out: NDArray[np.int32] | None = None,
+    *,
+    parallel: bool | None = None,
 ) -> NDArray[np.int32]: ...
 @overload
 def tokenize(
@@ -241,12 +243,16 @@ def tokenize(
     token_map: dict[str, int],
     unknown_token: int,
     out: None = None,
+    *,
+    parallel: bool | None = None,
 ) -> Ragged[np.int32]: ...
 def tokenize(
     seqs: StrSeqType | Ragged[np.bytes_],
     token_map: dict[str, int],
     unknown_token: int,
     out: NDArray[np.int32] | None = None,
+    *,
+    parallel: bool | None = None,
 ) -> NDArray[np.int32] | Ragged[np.int32]:
     """Tokenize sequences. Maps each character to its integer token.
     Characters absent from token_map are replaced with unknown_token.
@@ -262,6 +268,13 @@ def tokenize(
     out
         Output array to store the result in. Only valid for non-Ragged input.
         Must have dtype ``np.int32``; any other dtype raises ``TypeError``.
+    parallel
+        Escape hatch overriding the size-based heuristic for choosing between the
+        single-threaded ``np.take`` and the parallel Numba LUT gather. ``None``
+        (default) uses the heuristic (parallel past
+        ``_TOKENIZE_PARALLEL_THRESHOLD`` elements); ``True`` forces the parallel
+        kernel; ``False`` forces single-threaded. ``parallel=True`` is
+        incompatible with a non-C-contiguous ``out`` and raises ``ValueError``.
 
     Returns
     -------
@@ -283,20 +296,32 @@ def tokenize(
         n = len(seqs.lengths.ravel())
         trailing = seqs.data.shape[1:]
         u8 = seqs.data.view(np.uint8)
-        if u8.size < _TOKENIZE_PARALLEL_THRESHOLD:
-            flat = np.take(lut, u8)
-        else:
+        use_parallel = (
+            u8.size >= _TOKENIZE_PARALLEL_THRESHOLD if parallel is None else parallel
+        )
+        if use_parallel:
             flat = np.empty(u8.shape, dtype=np.int32)
             lut_gather(np.ascontiguousarray(u8).reshape(-1), lut, flat.reshape(-1))
+        else:
+            flat = np.take(lut, u8)
         return Ragged.from_offsets(flat, (n, None, *trailing), seqs.offsets)
 
     _seqs = cast_seqs(seqs)
     u8 = _seqs.view(np.uint8)
-    # A strided out= can't be flattened to a writable view, so it takes the
-    # np.take path (which handles arbitrary strides) regardless of size.
-    if u8.size < _TOKENIZE_PARALLEL_THRESHOLD or (
-        out is not None and not out.flags.c_contiguous
-    ):
+    # A strided out= can't be flattened to a writable view, so the parallel
+    # kernel can't write through it; such out= always takes the np.take path
+    # (which handles arbitrary strides). parallel=True can't honor it -> error.
+    out_blocks_parallel = out is not None and not out.flags.c_contiguous
+    if parallel is True and out_blocks_parallel:
+        raise ValueError(
+            "parallel=True requires a C-contiguous out array, got a "
+            "non-contiguous out. Use parallel=None/False or a contiguous out."
+        )
+    if parallel is None:
+        use_parallel = u8.size >= _TOKENIZE_PARALLEL_THRESHOLD
+    else:
+        use_parallel = parallel
+    if not use_parallel or out_blocks_parallel:
         return np.take(lut, u8, out=out)
     result = out if out is not None else np.empty(u8.shape, dtype=np.int32)
     lut_gather(np.ascontiguousarray(u8).reshape(-1), lut, result.reshape(-1))

--- a/skills/seqpro/SKILL.md
+++ b/skills/seqpro/SKILL.md
@@ -33,7 +33,7 @@ Python/Rust package for fast biological-sequence processing. Python+NumPy+Numba 
 | Normalize input | `sp.cast_seqs(x)` | → `|S1` bytes, or passthrough for OHE |
 | One-hot encode | `sp.ohe(x, alphabet, length_axis=-1)` | last axis added for OHE dim |
 | Decode OHE | `sp.decode_ohe(x, alphabet, ohe_axis=-1)` | |
-| Tokenize / detokenize | `sp.tokenize` / `sp.decode_tokens` | integer ids |
+| Tokenize / detokenize | `sp.tokenize` / `sp.decode_tokens` | integer ids; `parallel=True/False` forces/disables the parallel kernel (default `None` = size heuristic) |
 | Pad | `sp.pad_seqs(x, pad_val, length=...)` | |
 | Reverse complement | `sp.reverse_complement(x, alphabet, length_axis=-1)` | works on str/bytes/OHE |
 | K-mer shuffle | `sp.k_shuffle(x, k, length_axis=-1, seed=...)` | calls Rust `_k_shuffle` |

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -260,3 +260,53 @@ def test_tokenize_parallel_branch_matches_reference():
     rag = Ragged.from_lengths(data, lengths)
     rag_got = sp.tokenize(rag, token_map, unknown_token=4)
     np.testing.assert_array_equal(rag_got.data, ref(data.view(np.uint8)))
+
+
+def test_tokenize_parallel_override_forces_path(monkeypatch):
+    """parallel= overrides the size heuristic in both directions, while staying
+    correct. Spying on the parallel kernel reveals which branch ran."""
+    import seqpro._encoders as enc
+    from seqpro._encoders import _TOKENIZE_PARALLEL_THRESHOLD as THRESH
+
+    token_map = {"A": 0, "C": 1, "G": 2, "T": 3}
+    bases = np.frombuffer(b"ACGT", dtype="S1")
+
+    calls = {"n": 0}
+    real_lut = enc.lut_gather
+
+    def spy(*args, **kwargs):
+        calls["n"] += 1
+        return real_lut(*args, **kwargs)
+
+    monkeypatch.setattr(enc, "lut_gather", spy)
+
+    # small input, parallel=True -> parallel kernel used despite being below thresh
+    small = bases[np.zeros(8, dtype=int)]
+    assert small.size < THRESH
+    res = sp.tokenize(small, token_map, unknown_token=-1, parallel=True)
+    assert calls["n"] == 1
+    np.testing.assert_array_equal(res, np.zeros(8, dtype=np.int32))
+
+    # large input, parallel=False -> single-threaded np.take, kernel not used
+    calls["n"] = 0
+    large = bases[np.zeros(THRESH + 1000, dtype=int)]
+    res = sp.tokenize(large, token_map, unknown_token=-1, parallel=False)
+    assert calls["n"] == 0
+    np.testing.assert_array_equal(res, np.zeros(THRESH + 1000, dtype=np.int32))
+
+    # ragged honors the override too: small ragged forced parallel
+    calls["n"] = 0
+    data = bases[np.zeros(8, dtype=int)]
+    rag = Ragged.from_lengths(data, np.array([4, 4]))
+    sp.tokenize(rag, token_map, unknown_token=-1, parallel=True)
+    assert calls["n"] == 1
+
+
+def test_tokenize_parallel_true_rejects_noncontiguous_out():
+    """parallel=True cannot honor a non-C-contiguous out= buffer, so it raises."""
+    token_map = {"A": 0, "C": 1, "G": 2, "T": 3}
+    flat = np.frombuffer(b"ACGT" * 4, dtype="S1")
+    strided = np.empty((flat.size, 2), dtype=np.int32)[:, 0]
+    assert not strided.flags.c_contiguous
+    with pytest.raises(ValueError):
+        sp.tokenize(flat, token_map, unknown_token=-1, out=strided, parallel=True)


### PR DESCRIPTION
## Summary

`tokenize()` picks between single-threaded `np.take` and the parallel Numba LUT gather using an element-count threshold (`_TOKENIZE_PARALLEL_THRESHOLD`). When that heuristic is wrong for a given input/machine, callers had no override.

Adds a kw-only `parallel: bool | None = None`:
- `None` (default) — existing size heuristic, no behavior change.
- `True` — force the parallel kernel even below threshold.
- `False` — force single-threaded `np.take` even above threshold.

Applies to both the dense and `Ragged` paths.

`parallel=True` can't write through a non-C-contiguous `out=` (the kernel needs a flat writable view), so that combination raises `ValueError` rather than silently falling back — front-loaded validation tied to the explicit request. With `None`/`False`, a strided `out=` still takes the `np.take` path as before.

## Tests (TDD, written first)

- `test_tokenize_parallel_override_forces_path` — spies on `lut_gather` to prove `parallel=True` runs the kernel on tiny input and `parallel=False` skips it on large input, both correct; covers ragged.
- `test_tokenize_parallel_true_rejects_noncontiguous_out` — the `ValueError` guard.

All 13 tokenize tests pass; ruff clean. Pure-Python change, no Rust rebuild. `skills/seqpro/SKILL.md` updated per the signature-change convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)